### PR TITLE
feat: handle Swagger, output reformatting for LLM readability, only fetch specs when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ See `TESTING_WITH_OLLAMA.md` for detailed Ollama integration instructions.
 #### Test API Spec Fetching
 
 ```bash
-equinix-mcp-server --test-update-specs # --config path/to/custom/config.yaml
+equinix-mcp-server --update-specs # --config path/to/custom/config.yaml
 ```
+
+**Note:** The server uses cached API specifications by default for faster startup. Use `--update-specs` to force fetching fresh specs from remote sources.
 
 ## Server Configuration
 

--- a/TESTING_WITH_OLLAMA.md
+++ b/TESTING_WITH_OLLAMA.md
@@ -89,7 +89,7 @@ Before connecting to Ollama, verify the MCP server works:
 
 ```bash
 cd /path/to/equinix-mcp-server
-python -m equinix_mcp_server.main --test-update-specs
+python -m equinix_mcp_server.main --update-specs
 ```
 
 You should see all APIs load successfully.

--- a/config/apis.yaml
+++ b/config/apis.yaml
@@ -15,7 +15,7 @@ apis:
   network-edge:
     auth_type: "client_credentials"
     service_name: "network-edge"
-    enabled: false
+    enabled: true
     specs:
       - url: "https://docs.equinix.com/api-catalog/network-edgev1/openapi.yaml"
         overlay: "overlays/network-edge.yaml"

--- a/config/apis.yaml
+++ b/config/apis.yaml
@@ -5,8 +5,10 @@ apis:
     auth_type: "metal_token"
     service_name: "metal"
     include:
-      - metal_findPlans
-      - metal_findMetros
+      - findPlans
+      - findMetros
+    format:
+      getVirtualDevicesUsingGET: '.plans | map({id: .plan_id, slug: .slug, name: .name})'
     specs:
       - url: "https://docs.equinix.com/api-catalog/metalv1/openapi.yaml"
         overlay: "overlays/metal.yaml"
@@ -16,6 +18,9 @@ apis:
     auth_type: "client_credentials"
     service_name: "network-edge"
     enabled: true
+    # Example JQ formatting (future feature)
+    # format:
+    #   getVirtualDevicesUsingGET: '.data | map({id: .uuid, name: .name, status: .status})'
     specs:
       - url: "https://docs.equinix.com/api-catalog/network-edgev1/openapi.yaml"
         overlay: "overlays/network-edge.yaml"
@@ -25,9 +30,9 @@ apis:
     auth_type: "client_credentials"
     service_name: "fabric"
     include:
-      - fabric_searchConnections
-      - fabric_searchProviders
-      - fabric_getMetros
+      - searchConnections
+      - searchProviders
+      - getMetros
     specs:
       - url: "https://docs.equinix.com/api-catalog/fabricv4/openapi.yaml"
         overlay: "overlays/fabric.yaml"

--- a/config/apis.yaml
+++ b/config/apis.yaml
@@ -8,7 +8,36 @@ apis:
       - findPlans
       - findMetros
     format:
-      getVirtualDevicesUsingGET: '.plans | map({id: .plan_id, slug: .slug, name: .name})'
+      # Human-readable text format for plans - simplified and robust
+      findPlans: |
+        (if type == "array" then . else .plans end) | 
+        if length == 0 then 
+          "No plans available."
+        else
+          map(
+            "**" + (.name // .slug // "Unknown Plan") + "**\n" +
+            "- ID: " + (.id // "N/A") + "\n" +
+            "- Slug: " + (.slug // "N/A") + "\n" +
+            (if .description then "- Description: " + .description + "\n" else "" end) +
+            (if .pricing.hour then "- Hourly Price: $" + (.pricing.hour | tostring) + "\n" else "" end) +
+            (if .available_in then "- Available in " + (.available_in | length | tostring) + " locations\n" else "" end) +
+            (if .specs then 
+              "- Hardware: " + (
+                [
+                  (if .specs.cpus then (.specs.cpus | length | tostring) + " CPU types" else null end),
+                  (if .specs.memory then (.specs.memory.total // "Memory available") else null end),
+                  (if .specs.drives then (.specs.drives | length | tostring) + " storage options" else null end)
+                ] | map(select(. != null)) | join(", ")
+              ) + "\n" 
+            else "" end) +
+            "---\n"
+          ) | join("\n")
+        end
+      
+      # Simple metro listing
+      findMetros: |
+        (.metros | map(.code + " - " + .name + " (" + .country + ")") | sort | join("\n")) + 
+        "\n\nTotal metros: " + (.metros | length | tostring)
     specs:
       - url: "https://docs.equinix.com/api-catalog/metalv1/openapi.yaml"
         overlay: "overlays/metal.yaml"
@@ -33,6 +62,33 @@ apis:
       - searchConnections
       - searchProviders
       - getMetros
+    format:
+      # Human-readable connection summary
+      searchConnections:
+        summary: |
+          "Found " + (.data | length | tostring) + " connections:\n\n" +
+          (.data | map("• " + .name + " (" + .uuid + ") - " + .state + " " + .type) | join("\n"))
+        
+        detailed: |
+          .data | map(
+            "**" + .name + "** (" + .uuid + ")\n" +
+            "- State: " + .state + "\n" +
+            "- Type: " + .type + "\n" +
+            "- Description: " + (.description // "No description") + "\n" +
+            "- Speed: " + (.speed // "Not specified") + " Mbps\n" +
+            (if .bandwidth then "- Bandwidth: " + (.bandwidth | tostring) + " Mbps\n" else "" end) +
+            (if .project then "- Project: " + .project.name + "\n" else "" end) +
+            (if .redundancy then "- Redundancy: " + .redundancy.group + "\n" else "" end) +
+            "---"
+          ) | join("\n\n") | . + "\n\nTotal connections: " + (.data | length | tostring)
+        
+        default: |
+          "**Connection Summary**\n\n" +
+          (.data | map(
+            .name + " → " + .state + " (" + .type + ")" +
+            (if .speed then " @ " + (.speed | tostring) + "Mbps" else "" end)
+          ) | join("\n")) + 
+          "\n\n**Total:** " + (.data | length | tostring) + " connections"
     specs:
       - url: "https://docs.equinix.com/api-catalog/fabricv4/openapi.yaml"
         overlay: "overlays/fabric.yaml"

--- a/config/apis.yaml
+++ b/config/apis.yaml
@@ -52,7 +52,7 @@ apis:
     format:
       # Human-readable metros listing with pagination
       getMetrosUsingGET:
-        summary: |
+        - |
           "**Network Edge Metros**\n\n" +
           (.data | map(
             "• **" + (.metroCode // "??") + "** - " + (.metroDescription // "Unknown") + " (" + (.region // "No region") + ")" +

--- a/config/apis.yaml
+++ b/config/apis.yaml
@@ -46,10 +46,31 @@ apis:
   network-edge:
     auth_type: "client_credentials"
     service_name: "network-edge"
+    include:
+      - getMetrosUsingGET
     enabled: true
-    # Example JQ formatting (future feature)
-    # format:
-    #   getVirtualDevicesUsingGET: '.data | map({id: .uuid, name: .name, status: .status})'
+    format:
+      # Human-readable metros listing with pagination
+      getMetrosUsingGET:
+        summary: |
+          "**Network Edge Metros**\n\n" +
+          (.data | map(
+            "• **" + (.metroCode // "??") + "** - " + (.metroDescription // "Unknown") + " (" + (.region // "No region") + ")" +
+            (if .defaultIbx then " [IBX: " + .defaultIbx + "]" else "" end) +
+            (if .clusterSupported then " [Cluster supported]" else "" end)
+          ) | join("\n")) + 
+          "\n\n" +
+          (if .pagination then 
+            (if .pagination.total <= .pagination.limit then 
+              "**Total:** " + (.pagination.total | tostring) + " metros"
+            else
+              "**Page:** " + (((.pagination.offset // 0) / (.pagination.limit // 20) + 1) | floor | tostring) + 
+              "/" + (((.pagination.total // 0) / (.pagination.limit // 20)) | ceil | tostring) + 
+              " (showing " + (.data | length | tostring) + " of " + (.pagination.total | tostring) + " total metros)"
+            end)
+          else
+            "**Total:** " + (.data | length | tostring) + " metros"
+          end)
     specs:
       - url: "https://docs.equinix.com/api-catalog/network-edgev1/openapi.yaml"
         overlay: "overlays/network-edge.yaml"
@@ -89,6 +110,49 @@ apis:
             (if .speed then " @ " + (.speed | tostring) + "Mbps" else "" end)
           ) | join("\n")) + 
           "\n\n**Total:** " + (.data | length | tostring) + " connections"
+      
+      # Human-readable metros listing
+      getMetros:
+        summary: |
+          "**Fabric Metro Summary**\n\n" +
+          "Found " + (.data | length | tostring) + " metros (of " + (.pagination.total | tostring) + " total):\n\n" +
+          (.data | map("• **" + (.code // "??") + "** - " + (.name // "Unknown") + " (" + (.region // "No region") + ")") | join("\n"))
+        
+        detailed: |
+          "**Fabric Metro Details**\n\n" +
+          "Showing " + (.data | length | tostring) + " of " + (.pagination.total | tostring) + " metros:\n\n" +
+          (.data | map(
+            "**" + (.name // "Unknown Metro") + "** (" + (.code // "??") + ")\n" +
+            "- Region: " + (.region // "Not specified") + "\n" +
+            "- Equinix ASN: " + (.equinixAsn // "N/A" | tostring) + "\n" +
+            "- Max Local VC Bandwidth: " + ((.localVCBandwidthMax // 0 | tostring) + " Mbps") + "\n" +
+            (if .geoCoordinates then 
+              "- Location: " + (.geoCoordinates.latitude | tostring) + "°N, " + (.geoCoordinates.longitude | tostring) + "°E\n"
+            else "" end) +
+            (if .geoScopes and (.geoScopes | length > 0) then
+              "- Geo Scopes: " + (.geoScopes | join(", ")) + "\n"
+            else "" end) +
+            (if .services and (.services | length > 0) then
+              "- Services: " + (.services | map(.type) | join(", ")) + "\n"
+            else "" end) +
+            "- Connected to " + ((.connectedMetros // [] | length) | tostring) + " other metros\n" +
+            (if .connectedMetros and (.connectedMetros | length > 0) then
+              "  Top connections by latency:\n" +
+              (.connectedMetros | sort_by(.avgLatency // 999) | .[0:5] | map(
+                "    • " + (.code // "??") + " (" + ((.avgLatency // "N/A") | tostring) + "ms, " + ((.remoteVCBandwidthMax // 0) | tostring) + " Mbps max)"
+              ) | join("\n")) + 
+              (if (.connectedMetros | length) > 5 then "\n    ... and " + (((.connectedMetros | length) - 5) | tostring) + " more" else "" end) + "\n"
+            else "" end) +
+            "---"
+          ) | join("\n\n"))
+        
+        default: |
+          "**Fabric Metros**\n\n" +
+          (.data | map(
+            (.code // "??") + " → " + (.name // "Unknown") + " (" + (.region // "No region") + ")" +
+            (if .connectedMetros then " [" + ((.connectedMetros | length) | tostring) + " connections]" else "" end)
+          ) | join("\n")) + 
+          "\n\n**Total:** " + (.data | length | tostring) + " metros shown (of " + (.pagination.total | tostring) + " total)"
     specs:
       - url: "https://docs.equinix.com/api-catalog/fabricv4/openapi.yaml"
         overlay: "overlays/fabric.yaml"
@@ -102,6 +166,9 @@ apis:
         overlay: "overlays/billing.yaml"
   # SmartView APIs
   smartview:
+    service_name: "smartview"
+    include:
+      - getLocationHierarchy
     specs:
       - url: "https://docs.equinix.com/api-catalog/environmentalv1/openapi.yaml"
       - url: "https://docs.equinix.com/api-catalog/environmentalv2/openapi.yaml"

--- a/overlays/metal.yaml
+++ b/overlays/metal.yaml
@@ -59,7 +59,10 @@ actions:
     update:
       nullable: true
 
-  # Make Plan type property nullable
+  # Make Plan type property nullable and add null to enum
   - target: "$.components.schemas.Plan.properties.type"
     update:
+      type: "string"
+      enum: ["standard", "workload_optimized", "custom", null]
       nullable: true
+      description: "The plan type"

--- a/overlays/metal.yaml
+++ b/overlays/metal.yaml
@@ -58,3 +58,8 @@ actions:
   - target: "$.components.schemas.Meta.properties.self"
     update:
       nullable: true
+
+  # Make Plan type property nullable
+  - target: "$.components.schemas.Plan.properties.type"
+    update:
+      nullable: true

--- a/overlays/network-edge.yaml
+++ b/overlays/network-edge.yaml
@@ -1,43 +1,31 @@
-# Basic overlay for Network Edge API normalization
 overlay: "1.0.0"
 info:
   title: "Overlay for Network Edge API"
   version: "1.0.0"
-  description: "Overlay spec to normalize Network Edge API for merging"
 
 actions:
-  # Normalize the title
   - target: "$.info.title"
     update: "Equinix Network Edge API"
-    
-  # Standardize servers to use common base URL
+
   - target: "$.servers"
     update:
       - url: "https://api.equinix.com"
         description: "Equinix API Server"
-        
-  # Ensure all paths start with /network-edge/v1
-  - target: "$.paths"
-    transform: "prefix_paths"
-    options:
-      prefix: "/network-edge/v1"
-      
-  # Add consistent tags
-  - target: "$.paths.*.*.tags"
-    update: ["network-edge"]
-    merge: true
-    
-  # Normalize authentication to OAuth2
+
+  # Security schemes: keep ClientCredentials for token, use BearerAuth as default
   - target: "$.components.securitySchemes"
     update:
+      BearerAuth:
+        type: http
+        scheme: bearer
+        bearerFormat: JWT
       ClientCredentials:
-        type: "oauth2"
+        type: oauth2
         flows:
           clientCredentials:
             tokenUrl: "https://api.equinix.com/oauth2/v1/token"
             scopes: {}
-        
-  # Set default security
+
   - target: "$.security"
     update:
-      - ClientCredentials: []
+      - BearerAuth: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "jsonschema>=4.0.0",
     "openapi-spec-validator>=0.7.0",
     "prance>=23.6.21.0",
+    "jq>=1.6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/equinix_mcp_server/config.py
+++ b/src/equinix_mcp_server/config.py
@@ -47,6 +47,10 @@ class APIConfig(BaseModel):
         default_factory=list,
         description="Regex patterns of operationIds to exclude (after prefix)",
     )
+    format: Dict[str, str] = Field(
+        default_factory=dict,
+        description="JQ format strings per operationId for response transformation",
+    )
 
     # Backward-compat convenience properties (legacy single-spec shape)
     @property
@@ -135,6 +139,7 @@ class Config(BaseModel):
                     "enabled": api_data.get("enabled", True),
                     "include": api_data.get("include", []) or [],
                     "exclude": api_data.get("exclude", []) or [],
+                    "format": api_data.get("format", {}) or {},
                 }
 
                 apis[name] = APIConfig(**model_data)

--- a/src/equinix_mcp_server/config.py
+++ b/src/equinix_mcp_server/config.py
@@ -50,8 +50,8 @@ class APIConfig(BaseModel):
     format: Dict[str, Union[str, List[str], Dict[str, str]]] = Field(
         default_factory=dict,
         description="JQ format strings per operationId for response transformation. "
-                   "Can be a single string, list of strings (applied in sequence), "
-                   "or dict with named formats (e.g., {'summary': 'jq_filter', 'detailed': 'jq_filter2'})",
+        "Can be a single string, list of strings (applied in sequence), "
+        "or dict with named formats (e.g., {'summary': 'jq_filter', 'detailed': 'jq_filter2'})",
     )
 
     # Backward-compat convenience properties (legacy single-spec shape)

--- a/src/equinix_mcp_server/config.py
+++ b/src/equinix_mcp_server/config.py
@@ -7,7 +7,7 @@ namespace.
 """
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
 from pydantic import BaseModel, Field
@@ -47,9 +47,11 @@ class APIConfig(BaseModel):
         default_factory=list,
         description="Regex patterns of operationIds to exclude (after prefix)",
     )
-    format: Dict[str, str] = Field(
+    format: Dict[str, Union[str, List[str], Dict[str, str]]] = Field(
         default_factory=dict,
-        description="JQ format strings per operationId for response transformation",
+        description="JQ format strings per operationId for response transformation. "
+                   "Can be a single string, list of strings (applied in sequence), "
+                   "or dict with named formats (e.g., {'summary': 'jq_filter', 'detailed': 'jq_filter2'})",
     )
 
     # Backward-compat convenience properties (legacy single-spec shape)

--- a/src/equinix_mcp_server/main.py
+++ b/src/equinix_mcp_server/main.py
@@ -175,6 +175,8 @@ class AuthenticatedClient:
             return "metal"
         elif "/fabric/" in url:
             return "fabric"
+        elif "/ne/" in url:
+            return "network-edge"
         elif "/network-edge/" in url:
             return "network-edge"
         elif "/billing/" in url:

--- a/src/equinix_mcp_server/response_formatter.py
+++ b/src/equinix_mcp_server/response_formatter.py
@@ -1,0 +1,144 @@
+"""Response formatting utilities using JQ transformations and YAML serialization."""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Union
+
+import yaml
+
+from .config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class ResponseFormatter:
+    """Formats API responses using JQ transformations and serializes as YAML."""
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.jq_cache: Dict[str, Any] = {}
+        self._current_operation_id: Optional[str] = None
+
+    def set_operation_context(self, operation_id: Optional[str]) -> None:
+        """Set the current operation context for formatting decisions."""
+        self._current_operation_id = operation_id
+
+    def _get_jq_program(self, jq_filter: str) -> Any:
+        """Get compiled JQ program from cache or compile it."""
+        if jq_filter in self.jq_cache:
+            return self.jq_cache[jq_filter]
+
+        try:
+            import jq
+            
+            program = jq.compile(jq_filter)
+            self.jq_cache[jq_filter] = program
+            return program
+        except ImportError:
+            logger.warning("JQ library not available, response formatting disabled")
+            return None
+        except Exception as e:
+            logger.error(f"Failed to compile JQ filter '{jq_filter}': {e}")
+            return None
+
+    def _apply_jq_filters(self, data: Any, filters: List[str]) -> Any:
+        """Apply a list of JQ filters in sequence."""
+        result = data
+        logger.debug(f"Starting JQ transformation with {len(filters)} filters, input type: {type(data)}")
+        
+        for i, jq_filter in enumerate(filters):
+            try:
+                logger.debug(f"Applying JQ filter {i+1}/{len(filters)}: {jq_filter}")
+                program = self._get_jq_program(jq_filter)
+                if program is None:
+                    logger.warning(f"JQ program is None for filter: {jq_filter}")
+                    continue
+
+                # Apply the JQ transformation using the correct API
+                jq_result = program.input(result).all()
+                logger.debug(f"JQ raw result type: {type(jq_result)}, value: {repr(jq_result)[:200] if jq_result else 'None'}")
+                
+                # JQ returns a list of results, get the first one if single result
+                if isinstance(jq_result, list) and len(jq_result) == 1:
+                    result = jq_result[0]
+                    logger.debug(f"Extracted single result from list: {type(result)}")
+                else:
+                    result = jq_result
+                    logger.debug(f"Using raw result: {type(result)}")
+                
+                logger.debug(f"After filter {i+1}, result type: {type(result)}, value: {repr(result)[:200] if result else 'None'}")
+
+            except Exception as e:
+                logger.error(f"JQ transformation failed with filter '{jq_filter}': {e}")
+                logger.error(f"Input data type: {type(result)}")
+                # Continue with the current result if transformation fails
+                continue
+                
+        logger.debug(f"Final JQ result type: {type(result)}, value: {repr(result)[:200] if result else 'None'}")
+        return result
+
+    def _get_format_config(self, operation_id: str) -> Optional[Union[str, List[str], Dict[str, str]]]:
+        """Get format configuration for an operation ID."""
+        if "_" not in operation_id:
+            return None
+
+        api_name, original_operation_id = operation_id.split("_", 1)
+        api_config = self.config.get_api_config(api_name)
+
+        if not api_config or not api_config.format:
+            return None
+
+        return api_config.format.get(original_operation_id)
+
+    def format_response(self, operation_id: str, response_data: Any) -> Any:
+        """Format response data using configured JQ transformation."""
+        format_config = self._get_format_config(operation_id)
+        
+        if not format_config:
+            return response_data
+
+        logger.info(f"Applying format configuration to {operation_id}")
+
+        try:
+            if isinstance(format_config, str):
+                # Single JQ filter
+                return self._apply_jq_filters(response_data, [format_config])
+            
+            elif isinstance(format_config, list):
+                # List of JQ filters to apply in sequence
+                return self._apply_jq_filters(response_data, format_config)
+            
+            elif isinstance(format_config, dict):
+                # Named formats - use 'default' if available, otherwise first key
+                filter_name = "default" if "default" in format_config else next(iter(format_config))
+                jq_filter = format_config[filter_name]
+                logger.info(f"Using format '{filter_name}' for {operation_id}")
+                
+                if isinstance(jq_filter, str):
+                    return self._apply_jq_filters(response_data, [jq_filter])
+                elif isinstance(jq_filter, list):
+                    return self._apply_jq_filters(response_data, jq_filter)
+            
+            return response_data
+
+        except Exception as e:
+            logger.error(f"Format transformation failed for {operation_id}: {e}")
+            # Return original data if transformation fails
+            return response_data
+
+    def __call__(self, data: Any) -> str:
+        """FastMCP serializer interface - formats and serializes response data."""
+        # Apply JQ formatting if we have operation context
+        if self._current_operation_id:
+            data = self.format_response(self._current_operation_id, data)
+        
+        # Serialize as YAML for better LLM readability
+        try:
+            return yaml.dump(data, sort_keys=False, default_flow_style=False, allow_unicode=True)
+        except Exception as e:
+            logger.error(f"YAML serialization failed, falling back to JSON: {e}")
+            try:
+                return json.dumps(data, indent=2, ensure_ascii=False)
+            except Exception as json_error:
+                logger.error(f"JSON serialization also failed: {json_error}")
+                return str(data)

--- a/src/equinix_mcp_server/spec_manager.py
+++ b/src/equinix_mcp_server/spec_manager.py
@@ -120,9 +120,7 @@ class SpecManager:
                         base_spec.setdefault("components", {}), spec["components"]
                     )
                 if "$defs" in spec:
-                    logger.debug(
-                        f"Merging $defs for {api_name}: {spec.get('$defs')}"
-                    )
+                    logger.debug(f"Merging $defs for {api_name}: {spec.get('$defs')}")
                     deep_merge(base_spec.setdefault("$defs", {}), spec["$defs"])
 
         if base_spec is None:
@@ -266,19 +264,27 @@ class SpecManager:
             loc = param.get("in")
             name = str(param.get("name", ""))
             x_prefix = param.get("x-prefix") or param.get("x_prefix")
-            if loc == "header" and name.lower() == "authorization" and (
-                x_prefix is None or str(x_prefix).strip().lower().startswith("bearer")
+            if (
+                loc == "header"
+                and name.lower() == "authorization"
+                and (
+                    x_prefix is None
+                    or str(x_prefix).strip().lower().startswith("bearer")
+                )
             ):
                 auth_param_keys.add(key)
 
         # Ensure at least one bearer scheme exists to validate references if needed.
         sec_schemes: Dict[str, Any] = components.get("securitySchemes", {}) or {}
         if not any(
-            isinstance(v, dict) and v.get("type") == "http" and v.get("scheme") == "bearer"
+            isinstance(v, dict)
+            and v.get("type") == "http"
+            and v.get("scheme") == "bearer"
             for v in sec_schemes.values()
         ):
             sec_schemes.setdefault(
-                "BearerAuth", {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
+                "BearerAuth",
+                {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"},
             )
             components.setdefault("securitySchemes", sec_schemes)
             spec.setdefault("components", components)
@@ -313,7 +319,11 @@ class SpecManager:
                 new_params = []
                 found_auth = False
                 for p in params:
-                    if isinstance(p, dict) and "$ref" in p and isinstance(p["$ref"], str):
+                    if (
+                        isinstance(p, dict)
+                        and "$ref" in p
+                        and isinstance(p["$ref"], str)
+                    ):
                         ref = p["$ref"]
                         # Normalize possible refs to components.parameters
                         if ref.startswith("#/components/parameters/"):
@@ -383,8 +393,10 @@ class SpecManager:
             # Prefix all operationIds with the API name and filter paths
             if "paths" in spec:
                 # First, apply include/exclude filtering
-                filtered_paths = self._filter_paths_by_operation_id(api_name, spec["paths"])
-                
+                filtered_paths = self._filter_paths_by_operation_id(
+                    api_name, spec["paths"]
+                )
+
                 # Then prefix operationIds
                 for path, path_item in filtered_paths.items():
                     for method, operation in path_item.items():

--- a/src/equinix_mcp_server/spec_manager.py
+++ b/src/equinix_mcp_server/spec_manager.py
@@ -2,17 +2,8 @@
 
 This module is responsible for fetching, caching, merging, and applying
 overlays to OpenAPI specifications as defined in the configuration. It
-handles multiple spec sources per         for spec_source in api_config.specs:
-            if spec_source.overlay:
-                overlay_path = Path(spec_source.overlay)
-                if overlay_path.exists():
-                    with open(overlay_path, "r") as f:
-                        overlay = yaml.safe_load(f)
-                        spec = self.overlay_manager.apply(
-                            spec, api_config.name, overlay
-                        )
-        return spece and combines them into a
-single, coherent specification.
+handles multiple spec sources and combines them into a single, coherent
+specification.
 """
 
 import asyncio

--- a/src/equinix_mcp_server/swagger2openapi/LICENSE
+++ b/src/equinix_mcp_server/swagger2openapi/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017-2025 Mike Ralphson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/equinix_mcp_server/swagger2openapi/converter.py
+++ b/src/equinix_mcp_server/swagger2openapi/converter.py
@@ -1,0 +1,292 @@
+import copy
+import json
+import re
+
+def _walk_schema(schema, action):
+    """
+    Recursively walks a schema and applies an action.
+    """
+    action(schema)
+    if "items" in schema:
+        _walk_schema(schema["items"], action)
+    if "properties" in schema:
+        for prop_name, prop_schema in schema["properties"].items():
+            _walk_schema(prop_schema, action)
+    if "allOf" in schema:
+        for sub_schema in schema["allOf"]:
+            _walk_schema(sub_schema, action)
+    if "anyOf" in schema:
+        for sub_schema in schema["anyOf"]:
+            _walk_schema(sub_schema, action)
+    if "oneOf" in schema:
+        for sub_schema in schema["oneOf"]:
+            _walk_schema(sub_schema, action)
+    if "not" in schema:
+        _walk_schema(schema["not"], action)
+
+
+def _recurse(obj, action):
+    """
+    Recursively walks a dictionary/list structure and applies an action.
+    """
+    if isinstance(obj, dict):
+        action(obj)
+        for key, value in obj.items():
+            _recurse(value, action)
+    elif isinstance(obj, list):
+        for item in obj:
+            _recurse(item, action)
+
+
+class Swagger2OpenAPIConverter:
+    """
+    Faithful Python port of the core logic from swagger2openapi/index.js.
+    Handles security schemes, parameters, responses, schemas, extensions, and basic $ref rewriting.
+    """
+
+    def __init__(self):
+        self.options = {}
+
+    def _fix_up_sub_schema(self, schema):
+        """Ports the fixUpSubSchema function."""
+        if schema.get("discriminator") and isinstance(schema.get("discriminator"), str):
+            schema["discriminator"] = {"propertyName": schema["discriminator"]}
+        if schema.get("type") == "file":
+            schema["type"] = "string"
+            schema["format"] = "binary"
+        if "allowEmptyValue" in schema:
+            del schema["allowEmptyValue"]
+        if schema.get("type") == "null":
+            del schema["type"]
+            schema["nullable"] = True
+        if "x-nullable" in schema:
+            schema["nullable"] = schema.pop("x-nullable")
+
+    def _fix_up_schema(self, schema):
+        """Ports the fixUpSchema function."""
+        _walk_schema(schema, self._fix_up_sub_schema)
+
+    def _rewrite_ref(self, ref):
+        """Rewrites a Swagger $ref to an OpenAPI $ref."""
+        if ref.startswith("#/definitions/"):
+            return f"#/components/schemas/{ref[len('#/definitions/'):]}"
+        if ref.startswith("#/parameters/"):
+            return f"#/components/parameters/{ref[len('#/parameters/'):]}"
+        if ref.startswith("#/responses/"):
+            return f"#/components/responses/{ref[len('#/responses/'):]}"
+        return ref
+
+    def _fixup_refs(self, obj):
+        """Ports the fixupRefs function."""
+        if isinstance(obj, dict) and "$ref" in obj:
+            obj["$ref"] = self._rewrite_ref(obj["$ref"])
+
+    def _convert_security_definitions(self, secdefs):
+        """Converts security definitions."""
+        for name, scheme in secdefs.items():
+            if scheme.get("type") == "basic":
+                scheme["type"] = "http"
+                scheme["scheme"] = "basic"
+            elif scheme.get("type") == "oauth2":
+                flow = scheme.pop("flow")
+                flows = {}
+                if flow == "implicit":
+                    flows["implicit"] = {
+                        "authorizationUrl": scheme.pop("authorizationUrl"),
+                        "scopes": scheme.pop("scopes"),
+                    }
+                elif flow == "password":
+                    flows["password"] = {
+                        "tokenUrl": scheme.pop("tokenUrl"),
+                        "scopes": scheme.pop("scopes"),
+                    }
+                elif flow == "application":
+                    flows["clientCredentials"] = {
+                        "tokenUrl": scheme.pop("tokenUrl"),
+                        "scopes": scheme.pop("scopes"),
+                    }
+                elif flow == "accessCode":
+                    flows["authorizationCode"] = {
+                        "authorizationUrl": scheme.pop("authorizationUrl"),
+                        "tokenUrl": scheme.pop("tokenUrl"),
+                        "scopes": scheme.pop("scopes"),
+                    }
+                scheme["flows"] = flows
+        return secdefs
+
+    def _convert_operation(self, op, openapi):
+        """Converts a single operation."""
+        consumes = op.get("consumes", openapi.get("consumes", []))
+        produces = op.get("produces", openapi.get("produces", []))
+
+        # Parameters
+        if "parameters" in op:
+            form_data_params = [p for p in op["parameters"] if p.get("in") == "formData"]
+            body_param = next((p for p in op["parameters"] if p.get("in") == "body"), None)
+
+            if body_param:
+                op["requestBody"] = {"content": {}}
+                if body_param.get("description"):
+                    op["requestBody"]["description"] = body_param["description"]
+                if body_param.get("required"):
+                    op["requestBody"]["required"] = body_param["required"]
+                for content_type in consumes:
+                    op["requestBody"]["content"][content_type] = {
+                        "schema": body_param.get("schema", {})
+                    }
+
+            if form_data_params:
+                if "requestBody" not in op:
+                    op["requestBody"] = {"content": {}}
+                
+                content_type = "application/x-www-form-urlencoded"
+                if "multipart/form-data" in consumes:
+                    content_type = "multipart/form-data"
+
+                if content_type not in op["requestBody"]["content"]:
+                    op["requestBody"]["content"][content_type] = {
+                        "schema": {"type": "object", "properties": {}}
+                    }
+                
+                schema = op["requestBody"]["content"][content_type]["schema"]
+                required_fields = schema.get("required", [])
+
+                for param in form_data_params:
+                    prop_name = param["name"]
+                    prop_schema = {k: v for k, v in param.items() if k not in ["name", "in", "required"]}
+                    if param.get("type") == "file":
+                        prop_schema["type"] = "string"
+                        prop_schema["format"] = "binary"
+                    schema["properties"][prop_name] = prop_schema
+                    if param.get("required"):
+                        required_fields.append(prop_name)
+                
+                if required_fields:
+                    schema["required"] = required_fields
+
+            op["parameters"] = [
+                self._convert_parameter(p) 
+                for p in op["parameters"] 
+                if p.get("in") not in ["body", "formData"]
+            ]
+
+        # Responses
+        if "responses" in op:
+            for code, response in op["responses"].items():
+                if "schema" in response:
+                    schema = response.pop("schema")
+                    response["content"] = {}
+                    for content_type in produces:
+                        response["content"][content_type] = {"schema": schema}
+                if "headers" in response:
+                    for name, header in response["headers"].items():
+                        if "type" in header:
+                            header["schema"] = {"type": header.pop("type")}
+                            if "format" in header:
+                                header["schema"]["format"] = header.pop("format")
+
+    def _convert_parameter(self, param):
+        """Converts a single Swagger 2.0 parameter to OpenAPI 3.0."""
+        # This handles dereferenced parameters
+        if "schema" not in param and "type" in param:
+            schema = {}
+            # List of properties to move into the schema object
+            schema_properties = [
+                "type", "format", "items", "default", "maximum", 
+                "exclusiveMaximum", "minimum", "exclusiveMinimum", 
+                "maxLength", "minLength", "pattern", "maxItems", "minItems", 
+                "uniqueItems", "enum", "multipleOf", "collectionFormat"
+            ]
+            for key in schema_properties:
+                if key in param:
+                    schema[key] = param.pop(key)
+            param["schema"] = schema
+        return param
+
+    def convert(self, swagger):
+        """Main conversion method."""
+        openapi = copy.deepcopy(swagger)
+
+        openapi["openapi"] = "3.0.0"
+        openapi.pop("swagger", None)
+
+        # Convert host/basePath to servers
+        servers = []
+        scheme = "https"
+        if "schemes" in swagger and swagger["schemes"]:
+            scheme = swagger["schemes"][0]
+        
+        if "host" in swagger:
+            url = f"{scheme}://{swagger['host']}"
+            if "basePath" in swagger:
+                url += swagger["basePath"]
+            servers.append({"url": url})
+        
+        if servers:
+            openapi["servers"] = servers
+        
+        openapi.pop("host", None)
+        openapi.pop("basePath", None)
+        openapi.pop("schemes", None)
+
+        # Basic info
+        if "info" not in openapi:
+            openapi["info"] = {"title": "Converted API", "version": "1.0.0"}
+
+        # Create components object
+        openapi["components"] = openapi.get("components", {})
+
+        # Move top-level objects to components
+        for component_type in ["parameters", "responses"]:
+            if component_type in openapi:
+                openapi["components"][component_type] = openapi.pop(component_type)
+
+        if "definitions" in openapi:
+            openapi["components"]["schemas"] = openapi.pop("definitions")
+        
+        if "securityDefinitions" in openapi:
+            openapi["components"]["securitySchemes"] = self._convert_security_definitions(
+                openapi.pop("securityDefinitions")
+            )
+
+        # Process all schemas
+        if "schemas" in openapi["components"]:
+            for schema_name, schema in openapi["components"]["schemas"].items():
+                self._fix_up_schema(schema)
+
+        # Process paths
+        for path, path_item in openapi.get("paths", {}).items():
+            for method, op in path_item.items():
+                if method.lower() in ["get", "put", "post", "delete", "options", "head", "patch", "trace"]:
+                    self._convert_operation(op, openapi)
+
+        # Final pass to fix all $refs
+        _recurse(openapi, self._fixup_refs)
+
+        openapi.pop("consumes", None)
+        openapi.pop("produces", None)
+
+        return openapi
+
+
+# Example usage
+if __name__ == "__main__":
+    # This part is for standalone testing and can be removed or adapted
+    try:
+        with open("swagger.json", "r", encoding="utf-8") as f:
+            swagger_spec = json.load(f)
+
+        converter = Swagger2OpenAPIConverter()
+        openapi_spec = converter.convert(swagger_spec)
+
+        with open("openapi.json", "w", encoding="utf-8") as f:
+            json.dump(openapi_spec, f, indent=2, ensure_ascii=False)
+        
+        print("Conversion successful: openapi.json created.")
+
+    except FileNotFoundError:
+        print("Error: swagger.json not found. Please provide a Swagger 2.0 spec file.")
+    except json.JSONDecodeError:
+        print("Error: Invalid JSON in swagger.json.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")

--- a/tests/test_openapi_overlays.py
+++ b/tests/test_openapi_overlays.py
@@ -141,8 +141,9 @@ def test_apply_overlay_missing_target(overlay_manager):
 
     result = overlay_manager.apply(spec, "test", overlay)
 
-    # Should be unchanged since target doesn't exist
-    assert "info" not in result
+    # Should create the missing intermediate node and set the value
+    assert "info" in result
+    assert result["info"]["title"] == "New Title"
     assert "paths" in result
 
 

--- a/tests/test_response_formatter_ne.py
+++ b/tests/test_response_formatter_ne.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repo "src" is on path when running tests directly
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from equinix_mcp_server.config import APIConfig, Config
+from equinix_mcp_server.response_formatter import ResponseFormatter
+
+
+def test_network_edge_get_metros_format_lookup():
+    """Ensure the ResponseFormatter finds the Network Edge getMetros format
+    for multiple operation id variants (double-underscore, single underscore,
+    and underscore-normalized forms). This test constructs a minimal in-memory
+    Config so it doesn't depend on the repo's yaml file being present.
+    """
+
+    # Minimal fake format (content isn't executed in this test)
+    fake_format = [".data | map(.metroCode)"]
+
+    api_cfg = APIConfig(name="network-edge", format={"getMetrosUsingGET": fake_format})
+    cfg = Config(apis={"network-edge": api_cfg})
+    rf = ResponseFormatter(cfg)
+
+    candidates = [
+        "network-edge__getMetrosUsingGET",
+        "network-edge_getMetrosUsingGET",
+        "network_edge__getMetrosUsingGET",
+    ]
+
+    for op in candidates:
+        fmt = rf._get_format_config(op)
+        assert fmt is not None, f"Formatter did not find format for operation id: {op}"
+        # We set the fake format as a list above
+        assert isinstance(fmt, list), f"Expected list-format for {op}, got {type(fmt)}"


### PR DESCRIPTION
This pull request introduces significant improvements to the Equinix MCP server by adding flexible, human-readable API response formatting via JQ filters, updating configuration and overlays to support this, and improving usability and logging. The changes make it easier to customize API output, especially for plans, metros, and connections, and improve the developer experience when testing and running the server.

**API Response Formatting Enhancements:**

* Added a `format` section to each API in `config/apis.yaml`, allowing per-operation JQ filters for transforming API responses into human-readable summaries and details. This is especially detailed for `metal`, `fabric`, and `network-edge` APIs, supporting multiple output formats (summary, detailed, default) for operations like `findPlans`, `findMetros`, `searchConnections`, and `getMetros`. [[1]](diffhunk://#diff-0ccf882f65cdd316800d9b6cabde6d3293fe1e49f9cb451ecfa5620622d3b10eL8-R40) [[2]](diffhunk://#diff-0ccf882f65cdd316800d9b6cabde6d3293fe1e49f9cb451ecfa5620622d3b10eL18-R73) [[3]](diffhunk://#diff-0ccf882f65cdd316800d9b6cabde6d3293fe1e49f9cb451ecfa5620622d3b10eL28-R155)
* Updated the `APIConfig` model in `src/equinix_mcp_server/config.py` to support the new `format` field, allowing strings, lists, or dicts for flexible formatting. The config loader now reads this field. [[1]](diffhunk://#diff-4d6aead3ab162f195c3031a8e5dd4aae9435ad9786eeab5f1fc6c22114aec289R50-R55) [[2]](diffhunk://#diff-4d6aead3ab162f195c3031a8e5dd4aae9435ad9786eeab5f1fc6c22114aec289R144)
* Added the `jq` Python dependency to enable JQ-based response transformation.

**API Overlay and Spec Improvements:**

* Updated overlays for `metal` and `network-edge` APIs to normalize schemas, support nullable plan types, and standardize authentication schemes, improving compatibility and merging. [[1]](diffhunk://#diff-4d7dc1e252247352b2e93e0e25c0269a0d764e0a385af213af60bb252a653b6cR61-R68) [[2]](diffhunk://#diff-478c3d6b6946a98ca5c527526e905fe0c94c583b21dc134e6eeccf7e878325e6L1-R31)
* Added a new `smartview` API entry with included operation to the config.

**Usability and Developer Experience:**

* Improved server logging configuration with a new `_configure_logging` helper, reducing noise from third-party libraries and making log level configurable.
* Updated command-line arguments and documentation to use `--update-specs` instead of the deprecated `--test-update-specs`, and clarified the use of cached specs for faster startup. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R149) [[2]](diffhunk://#diff-49eb2aa6717a255a1a65fc9d740a80b1b812a65aad4a488f2be2e1e6d66f7b62L92-R92)

**Codebase and Service Routing:**

* Enhanced service detection in the main server logic to better route requests to the correct service (e.g., `network-edge`), supporting both `/ne/` and `/network-edge/` URL prefixes.
* Updated type hints and imports in `config.py` for better clarity and robustness.