### PR TITLE
Add modular docs, discovery, and execution MCP server entry points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.local
 .envrc
 .venv
 env/
@@ -190,7 +191,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project is an experimental Model Context Protocol (MCP) server, for local u
    - **Arazzo Workflows (Experimental)**: Define and execute higher-level workflows chaining multiple API operations
 - **Documentation Integration**: Search Equinix documentation via sitemap and Lunr search, fetch full markdown content
    - OpenAI MCP compatible `search` and `fetch` tools for ChatGPT Connectors and deep research
+- **Modular Server Entry Points**: Run the combined server or narrower docs, discovery, and execution servers depending on the MCP client's needs
 
 ## Supported APIs
 
@@ -107,6 +108,17 @@ The server uses cached API specifications by default for faster startup. Use `--
 equinix-docs-mcp-server --update-specs # --config path/to/custom/config.yaml
 ```
 
+#### Dedicated Server Entry Points
+
+Use the combined server when you want one MCP endpoint with everything, or run one of the narrower entry points when you want to reduce tool surface area:
+
+```bash
+equinix-docs-mcp-server
+equinix-docs-server
+equinix-discovery-server
+equinix-execution-server
+```
+
 ## Server Configuration
 
 The server is configured via `config/apis.yaml`. This file defines:
@@ -157,7 +169,10 @@ The server exposes MCP tools for:
    - `fetch` - Fetch full markdown content of a documentation page by URL (OpenAI MCP compatible)
    - `list_docs` - List and filter documentation
    - `find_docs` - Find documentation by filename/title matching
-3. **Workflows (Arazzo)**:
+3. **API Discovery**:
+   - `search_api` - Search indexed tags, operations, and paths from the merged OpenAPI specs
+   - `fetch_api` - Fetch the full indexed definition for a tag, operationId, or path
+4. **Workflows (Arazzo)**:
     - Tools prefixed with `workflow__` represent multi-step orchestrations defined in Arazzo-like YAML files.
     - Example: `workflow__list_metal_metros_then_prices`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "jq>=1.6.0",
     "jinja2>=3.1.0",
     "arazzo-runner>=0.1.4",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -40,6 +41,9 @@ dev = [
 
 [project.scripts]
 equinix-docs-mcp-server = "equinix_docs_mcp_server.main:main"
+equinix-docs-server = "equinix_docs_mcp_server.servers.docs:main"
+equinix-discovery-server = "equinix_docs_mcp_server.servers.discovery:main"
+equinix-execution-server = "equinix_docs_mcp_server.servers.execution:main"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/src/equinix_docs_mcp_server/discovery.py
+++ b/src/equinix_docs_mcp_server/discovery.py
@@ -1,0 +1,113 @@
+"""OpenAPI Discovery module for indexing and searching API specifications."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .config import Config
+from .spec_manager import SpecManager
+
+logger = logging.getLogger(__name__)
+
+class DiscoveryManager:
+    """Manages discovery of OpenAPI elements (tags, operations, paths)."""
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.spec_manager = SpecManager(config)
+        self._index: Optional[Dict[str, Any]] = None
+
+    async def ensure_index(self):
+        """Ensure the search index is built."""
+        if self._index is not None:
+            return
+
+        # Ensure specs are loaded
+        if not self.spec_manager.has_all_cached_specs():
+            await self.spec_manager.update_specs()
+        
+        merged_spec = self.spec_manager.get_merged_spec()
+        self._build_index(merged_spec)
+
+    def _build_index(self, spec: Dict[str, Any]):
+        """Build search index from OpenAPI spec."""
+        self._index = {
+            "tags": {},
+            "operations": {},
+            "paths": {}
+        }
+
+        # Index Tags
+        if "tags" in spec:
+            for tag in spec["tags"]:
+                name = tag.get("name")
+                if name:
+                    self._index["tags"][name] = tag
+
+        # Index Paths and Operations
+        if "paths" in spec:
+            for path, path_item in spec["paths"].items():
+                self._index["paths"][path] = path_item
+                
+                for method, operation in path_item.items():
+                    if method in ["get", "put", "post", "delete", "patch", "head", "options", "trace"]:
+                        op_id = operation.get("operationId")
+                        if op_id:
+                            # Store full operation context
+                            self._index["operations"][op_id] = {
+                                "method": method,
+                                "path": path,
+                                "details": operation
+                            }
+                        
+                        # Also index tags from operations if not already present
+                        for tag_name in operation.get("tags", []):
+                            if tag_name not in self._index["tags"]:
+                                self._index["tags"][tag_name] = {"name": tag_name}
+
+    async def search_api(self, query: str, limit: int = 10) -> str:
+        """Search API elements (tags, operations, paths)."""
+        await self.ensure_index()
+        
+        query = query.lower()
+        results = []
+
+        # Search Tags
+        for name, tag in self._index["tags"].items():
+            if query in name.lower() or query in tag.get("description", "").lower():
+                results.append(f"TAG: {name} - {tag.get('description', 'No description')}")
+
+        # Search Operations
+        for op_id, op_data in self._index["operations"].items():
+            op = op_data["details"]
+            if (query in op_id.lower() or 
+                query in op.get("summary", "").lower() or 
+                query in op.get("description", "").lower()):
+                results.append(f"OP: {op_id} ({op_data['method'].upper()} {op_data['path']}) - {op.get('summary', '')}")
+
+        # Search Paths
+        for path in self._index["paths"].keys():
+            if query in path.lower():
+                results.append(f"PATH: {path}")
+
+        # Limit results
+        return "\n".join(results[:limit])
+
+    async def fetch_api(self, target: str) -> str:
+        """Fetch details for a specific API element (tag, operationId, or path)."""
+        await self.ensure_index()
+        
+        import yaml
+
+        # Check Operations
+        if target in self._index["operations"]:
+            return yaml.dump(self._index["operations"][target], sort_keys=False)
+
+        # Check Tags
+        if target in self._index["tags"]:
+            return yaml.dump(self._index["tags"][target], sort_keys=False)
+
+        # Check Paths
+        if target in self._index["paths"]:
+            return yaml.dump(self._index["paths"][target], sort_keys=False)
+
+        return f"Target '{target}' not found in API index."

--- a/src/equinix_docs_mcp_server/env.py
+++ b/src/equinix_docs_mcp_server/env.py
@@ -1,0 +1,9 @@
+"""Environment loading helpers for CLI entry points."""
+
+from dotenv import load_dotenv
+
+
+def load_project_env() -> None:
+    """Load local override env first, then the default .env file."""
+    load_dotenv(".env.local")
+    load_dotenv()

--- a/src/equinix_docs_mcp_server/main.py
+++ b/src/equinix_docs_mcp_server/main.py
@@ -13,8 +13,10 @@ from .arazzo_manager import ArazzoManager
 from .auth import AuthManager
 from .config import Config
 from .docs import DocsManager
+from .env import load_project_env
 from .response_formatter import ResponseFormatter
 from .spec_manager import SpecManager
+from .discovery import DiscoveryManager
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -202,15 +204,26 @@ class AuthenticatedClient:
 class EquinixMCPServer:
     """Main Equinix MCP Server class leveraging FastMCP's OpenAPI integration."""
 
-    def __init__(self, config_path: str = "config/apis.yaml"):
+    def __init__(
+        self, 
+        config_path: str = "config/apis.yaml",
+        enable_docs: bool = True,
+        enable_discovery: bool = True,
+        enable_execution: bool = True
+    ):
         """Initialize the server with configuration."""
         self.config = Config.load(config_path)
         self.auth_manager = AuthManager(self.config)
         self.spec_manager = SpecManager(self.config)
         self.docs_manager = DocsManager(self.config)
+        self.discovery_manager = DiscoveryManager(self.config)
         self.response_formatter = ResponseFormatter(self.config)
         self.arazzo_manager = ArazzoManager(self.config, auth_manager=self.auth_manager)
         self.mcp: Optional[Any] = None  # Will be initialized in initialize()
+        
+        self.enable_docs = enable_docs
+        self.enable_discovery = enable_discovery
+        self.enable_execution = enable_execution
 
     async def initialize(self, force_update_specs: bool = False) -> None:
         """Initialize the server components using FastMCP's OpenAPI integration."""
@@ -220,17 +233,19 @@ class EquinixMCPServer:
         os.environ["FASTMCP_EXPERIMENTAL_ENABLE_NEW_OPENAPI_PARSER"] = "true"
 
         # Load and merge API specs - only update if forced or no cached specs exist
-        needs_update = (
-            force_update_specs or not self.spec_manager.has_all_cached_specs()
-        )
+        # We need specs for both execution and discovery
+        if self.enable_execution or self.enable_discovery:
+            needs_update = (
+                force_update_specs or not self.spec_manager.has_all_cached_specs()
+            )
 
-        if needs_update:
-            logger.info("Updating API specifications from remote sources...")
-            await self.spec_manager.update_specs()
-        else:
-            logger.info("Using cached API specifications for faster startup")
+            if needs_update:
+                logger.info("Updating API specifications from remote sources...")
+                await self.spec_manager.update_specs()
+            else:
+                logger.info("Using cached API specifications for faster startup")
 
-        merged_spec = self.spec_manager.get_merged_spec()
+        merged_spec = self.spec_manager.get_merged_spec() if (self.enable_execution or self.enable_discovery) else {}
 
         # Create authenticated HTTP client for API calls
         client = AuthenticatedClient(
@@ -250,26 +265,33 @@ class EquinixMCPServer:
             ),
         )
 
-        # Create a temporary FastMCP instance to get the tools, then apply transformations
-        temp_mcp = FastMCP.from_openapi(
-            openapi_spec=merged_spec,
-            client=client,  # type: ignore[arg-type]
-            name="Temp",
-        )
+        # 1. Execution Tools (OpenAPI)
+        if self.enable_execution:
+            # Create a temporary FastMCP instance to get the tools, then apply transformations
+            temp_mcp = FastMCP.from_openapi(
+                openapi_spec=merged_spec,
+                client=client,  # type: ignore[arg-type]
+                name="Temp",
+            )
 
-        # Apply tool transformations for formatting and transfer to main instance
-        await self._apply_tool_transformations(temp_mcp)
-        # Local workaround: ensure tool output schemas include required $defs
-        await self._attach_defs_to_tool_schemas(merged_spec)
+            # Apply tool transformations for formatting and transfer to main instance
+            await self._apply_tool_transformations(temp_mcp)
+            # Local workaround: ensure tool output schemas include required $defs
+            await self._attach_defs_to_tool_schemas(merged_spec)
 
-        # Set up context-aware serialization by decorating tools
-        # await self._setup_context_aware_tools()  # Replaced by tool transformations
+        # 2. Discovery Tools
+        if self.enable_discovery:
+            await self._register_discovery_tools()
 
-        # Register additional documentation tools that aren't part of the API
-        await self._register_docs_tools()
-        # Load and register Arazzo workflows (after API tools exist)
-        await self.arazzo_manager.load()
-        await self.arazzo_manager.register_with_fastmcp(self.mcp)
+        # 3. Documentation Tools
+        if self.enable_docs:
+            await self._register_docs_tools()
+            
+        # 4. Arazzo Workflows
+        if self.enable_execution:
+            # Load and register Arazzo workflows (after API tools exist)
+            await self.arazzo_manager.load()
+            await self.arazzo_manager.register_with_fastmcp(self.mcp)
 
     async def _apply_tool_transformations(self, temp_mcp: Any) -> None:
         """Apply tool transformations for formatting and transfer tools to main instance."""
@@ -600,6 +622,29 @@ class EquinixMCPServer:
             """Find documentation by filename-based search."""
             return await self.docs_manager.find_docs(query)
 
+    async def _register_discovery_tools(self) -> None:
+        """Register discovery tools on the FastMCP server."""
+        assert self.mcp is not None, "MCP server must be initialized first"
+        
+        # Ensure index is built
+        await self.discovery_manager.ensure_index()
+
+        @self.mcp.tool(
+            name="search_api",
+            description="Search for API tags, operations, or paths. Returns a list of matching elements.",
+        )
+        async def search_api(query: str, limit: int = 10) -> str:
+            """Search API elements."""
+            return await self.discovery_manager.search_api(query, limit)
+
+        @self.mcp.tool(
+            name="fetch_api",
+            description="Fetch details for a specific API element (tag name, operationId, or path). Returns the full schema/definition.",
+        )
+        async def fetch_api(target: str) -> str:
+            """Fetch API element details."""
+            return await self.discovery_manager.fetch_api(target)
+
     async def run(self, force_update_specs: bool = False) -> None:
         """Run the MCP server."""
         await self.initialize(force_update_specs)
@@ -705,6 +750,9 @@ def main(config: str, update_specs: bool, log_level: str) -> None:
 
     # Configure logging based on the provided level
     _configure_logging(log_level.upper())
+
+    # Load environment variables with local overrides first.
+    load_project_env()
 
     async def _main() -> None:
         server = EquinixMCPServer(config)

--- a/src/equinix_docs_mcp_server/servers/discovery.py
+++ b/src/equinix_docs_mcp_server/servers/discovery.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+import click
+from fastmcp import FastMCP
+
+from ..config import Config
+from ..discovery import DiscoveryManager
+from ..env import load_project_env
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+def _configure_logging(log_level: str):
+    """Configure logging."""
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper()),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+
+class EquinixDiscoveryServer:
+    """Dedicated Equinix OpenAPI Discovery MCP Server."""
+
+    def __init__(self, config_path: str = "config/apis.yaml"):
+        self.config = Config.load(config_path)
+        self.discovery_manager = DiscoveryManager(self.config)
+        self.mcp = FastMCP(
+            name="Equinix Discovery Server",
+            instructions="Provides tools to discover and inspect Equinix API specifications (tags, operations, paths)."
+        )
+
+    async def initialize(self):
+        """Initialize the server and register tools."""
+        # Ensure index is built on startup
+        await self.discovery_manager.ensure_index()
+
+        @self.mcp.tool(
+            name="search_api",
+            description="Search for API tags, operations, or paths. Returns a list of matching elements.",
+        )
+        async def search_api(query: str, limit: int = 10) -> str:
+            """Search API elements."""
+            return await self.discovery_manager.search_api(query, limit)
+
+        @self.mcp.tool(
+            name="fetch_api",
+            description="Fetch details for a specific API element (tag name, operationId, or path). Returns the full schema/definition.",
+        )
+        async def fetch_api(target: str) -> str:
+            """Fetch API element details."""
+            return await self.discovery_manager.fetch_api(target)
+
+    async def run(self):
+        """Run the server."""
+        await self.initialize()
+        await self.mcp.run_stdio_async()
+
+@click.command()
+@click.option("--config", "-c", default="config/apis.yaml", help="Configuration file path")
+@click.option("--log-level", default="INFO", help="Logging level")
+def main(config: str, log_level: str):
+    """Start the Equinix Discovery MCP Server."""
+    _configure_logging(log_level)
+    load_project_env()
+    
+    server = EquinixDiscoveryServer(config)
+    asyncio.run(server.run())
+
+if __name__ == "__main__":
+    main()

--- a/src/equinix_docs_mcp_server/servers/docs.py
+++ b/src/equinix_docs_mcp_server/servers/docs.py
@@ -1,0 +1,86 @@
+import asyncio
+import logging
+from typing import Optional
+
+import click
+from fastmcp import FastMCP
+
+from ..config import Config
+from ..docs import DocsManager
+from ..env import load_project_env
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+def _configure_logging(log_level: str):
+    """Configure logging."""
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper()),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+
+class EquinixDocsServer:
+    """Dedicated Equinix Documentation MCP Server."""
+
+    def __init__(self, config_path: str = "config/apis.yaml"):
+        self.config = Config.load(config_path)
+        self.docs_manager = DocsManager(self.config)
+        self.mcp = FastMCP(
+            name="Equinix Docs Server",
+            instructions="Provides access to Equinix documentation via search and fetch tools."
+        )
+
+    async def initialize(self):
+        """Initialize the server and register tools."""
+        # Register tools
+        @self.mcp.tool(
+            name="search",
+            description="Search Equinix documentation using full-text search. Returns URLs that can be fetched with the 'fetch' tool.",
+        )
+        async def search(query: str, limit: int = 8) -> str:
+            """Search documentation."""
+            return await self.docs_manager.search_docs(query, limit)
+
+        @self.mcp.tool(
+            name="fetch",
+            description="Fetch the full markdown content of an Equinix documentation page by URL.",
+        )
+        async def fetch(url: str) -> str:
+            """Fetch documentation content."""
+            return await self.docs_manager.fetch_doc(url)
+
+        @self.mcp.tool(
+            name="list_docs",
+            description="List and filter Equinix documentation by topic, product, or keywords.",
+        )
+        async def list_docs(filter_term: Optional[str] = None) -> str:
+            """List documentation."""
+            return await self.docs_manager.list_docs(filter_term)
+
+        @self.mcp.tool(
+            name="find_docs", 
+            description="Find Equinix documentation by filename"
+        )
+        async def find_docs(query: str) -> str:
+            """Find documentation by filename."""
+            return await self.docs_manager.find_docs(query)
+
+    async def run(self):
+        """Run the server."""
+        await self.initialize()
+        await self.mcp.run_stdio_async()
+
+@click.command()
+@click.option("--config", "-c", default="config/apis.yaml", help="Configuration file path")
+@click.option("--log-level", default="INFO", help="Logging level")
+def main(config: str, log_level: str):
+    """Start the Equinix Docs MCP Server."""
+    _configure_logging(log_level)
+    load_project_env()
+    
+    server = EquinixDocsServer(config)
+    asyncio.run(server.run())
+
+if __name__ == "__main__":
+    main()

--- a/src/equinix_docs_mcp_server/servers/execution.py
+++ b/src/equinix_docs_mcp_server/servers/execution.py
@@ -1,0 +1,56 @@
+import asyncio
+import logging
+import click
+from fastmcp import FastMCP
+
+from ..config import Config
+from ..spec_manager import SpecManager
+from ..auth import AuthManager
+from ..response_formatter import ResponseFormatter
+from ..env import load_project_env
+from ..main import AuthenticatedClient, EquinixMCPServer
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+def _configure_logging(log_level: str):
+    """Configure logging."""
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper()),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+
+class EquinixExecutionServer:
+    """Dedicated Equinix API Execution MCP Server."""
+
+    def __init__(self, config_path: str = "config/apis.yaml"):
+        # Reuse the logic from the main server class but scoped to execution
+        self.delegate = EquinixMCPServer(
+            config_path,
+            enable_docs=False,
+            enable_discovery=False,
+            enable_execution=True
+        )
+        
+    async def run(self, force_update_specs: bool = False):
+        """Run the server."""
+        # The main EquinixMCPServer implementation already does exactly what we want
+        # for the execution server: loads specs, creates client, registers tools.
+        # We just need to run it.
+        await self.delegate.run(force_update_specs)
+
+@click.command()
+@click.option("--config", "-c", default="config/apis.yaml", help="Configuration file path")
+@click.option("--update-specs", is_flag=True, help="Force update API specs")
+@click.option("--log-level", default="INFO", help="Logging level")
+def main(config: str, update_specs: bool, log_level: str):
+    """Start the Equinix Execution MCP Server."""
+    _configure_logging(log_level)
+    load_project_env()
+    
+    server = EquinixExecutionServer(config)
+    asyncio.run(server.run(update_specs))
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Test fixtures and configuration."""
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 
@@ -13,12 +14,16 @@ def test_environment():
     # Ensure we're in the right directory
     original_cwd = os.getcwd()
     repo_root = Path(__file__).parent.parent
+    src_path = repo_root / "src"
+    sys.path.insert(0, str(src_path))
     os.chdir(repo_root)
 
     yield
 
     # Cleanup
     os.chdir(original_cwd)
+    if str(src_path) in sys.path:
+        sys.path.remove(str(src_path))
 
 
 @pytest.fixture

--- a/tests/test_modular_servers.py
+++ b/tests/test_modular_servers.py
@@ -1,0 +1,116 @@
+"""Tests for the dedicated docs, discovery, and execution server entry points."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from equinix_docs_mcp_server.main import EquinixMCPServer
+from equinix_docs_mcp_server.servers.discovery import EquinixDiscoveryServer
+from equinix_docs_mcp_server.servers.docs import EquinixDocsServer
+from equinix_docs_mcp_server.servers.execution import EquinixExecutionServer
+
+
+def _tool_decorator_collector(registry: list[dict[str, str]]):
+    """Collect tool registrations without depending on FastMCP internals."""
+
+    def decorator(*, name: str, description: str):
+        def register(fn):
+            registry.append({"name": name, "description": description, "fn": fn})
+            return fn
+
+        return register
+
+    return decorator
+
+
+@pytest.mark.asyncio
+async def test_docs_server_registers_docs_tools():
+    """Docs server should expose only documentation tools."""
+    registered_tools = []
+
+    with patch(
+        "equinix_docs_mcp_server.servers.docs.Config.load", return_value=MagicMock()
+    ), patch(
+        "equinix_docs_mcp_server.servers.docs.DocsManager", return_value=MagicMock()
+    ), patch("equinix_docs_mcp_server.servers.docs.FastMCP") as mock_fastmcp:
+        mock_mcp = MagicMock()
+        mock_mcp.tool = _tool_decorator_collector(registered_tools)
+        mock_fastmcp.return_value = mock_mcp
+
+        server = EquinixDocsServer("test_config.yaml")
+        await server.initialize()
+
+    assert [tool["name"] for tool in registered_tools] == [
+        "search",
+        "fetch",
+        "list_docs",
+        "find_docs",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_discovery_server_registers_discovery_tools():
+    """Discovery server should expose only OpenAPI discovery tools."""
+    registered_tools = []
+    discovery_manager = MagicMock()
+    discovery_manager.ensure_index = AsyncMock()
+
+    with patch(
+        "equinix_docs_mcp_server.servers.discovery.Config.load",
+        return_value=MagicMock(),
+    ), patch(
+        "equinix_docs_mcp_server.servers.discovery.DiscoveryManager",
+        return_value=discovery_manager,
+    ), patch("equinix_docs_mcp_server.servers.discovery.FastMCP") as mock_fastmcp:
+        mock_mcp = MagicMock()
+        mock_mcp.tool = _tool_decorator_collector(registered_tools)
+        mock_fastmcp.return_value = mock_mcp
+
+        server = EquinixDiscoveryServer("test_config.yaml")
+        await server.initialize()
+
+    discovery_manager.ensure_index.assert_called_once()
+    assert [tool["name"] for tool in registered_tools] == ["search_api", "fetch_api"]
+
+
+def test_execution_server_scopes_delegate_to_execution_only():
+    """Execution server should disable docs and discovery tool registration."""
+    with patch("equinix_docs_mcp_server.servers.execution.EquinixMCPServer") as mock_cls:
+        delegate = MagicMock()
+        mock_cls.return_value = delegate
+
+        server = EquinixExecutionServer("test_config.yaml")
+
+    mock_cls.assert_called_once_with(
+        "test_config.yaml",
+        enable_docs=False,
+        enable_discovery=False,
+        enable_execution=True,
+    )
+    assert server.delegate is delegate
+
+
+@pytest.mark.asyncio
+async def test_execution_server_run_delegates_to_main_server():
+    """Execution server should forward run options to the shared implementation."""
+    with patch("equinix_docs_mcp_server.servers.execution.EquinixMCPServer") as mock_cls:
+        delegate = MagicMock()
+        delegate.run = AsyncMock()
+        mock_cls.return_value = delegate
+
+        server = EquinixExecutionServer("test_config.yaml")
+        await server.run(force_update_specs=True)
+
+    delegate.run.assert_called_once_with(True)
+
+
+def test_mux_server_initializes_all_tool_groups_by_default():
+    """Main server should keep the multiplexed server enabled by default."""
+    with patch("equinix_docs_mcp_server.main.Config.load") as mock_load:
+        mock_load.return_value = MagicMock()
+
+        server = EquinixMCPServer("test_config.yaml")
+
+    assert server.enable_docs is True
+    assert server.enable_discovery is True
+    assert server.enable_execution is True


### PR DESCRIPTION
## Summary
- add dedicated docs, discovery, and execution MCP server entry points
- add OpenAPI discovery tools for searching and fetching indexed tags, operations, and paths
- share environment loading across CLI entry points and add focused test coverage

## Notes
- this is split out from local follow-on work after #13 merged
- llms.txt docs-index work is intentionally left to #15