### PR TITLE
Vet discovered specs: add 27 API families, repair authoring bugs, exercise every tool

### DIFF
--- a/docs/SPEC_VETTING.md
+++ b/docs/SPEC_VETTING.md
@@ -1,0 +1,53 @@
+# Spec vetting
+
+`scripts/vet_specs.py` exercises every generated API tool through the real MCP
+harness without touching the network:
+
+1. Sample arguments are generated from each tool's input schema (patterns are
+   satisfied via `exrex`, `$ref`/`allOf`/`oneOf`/enums/formats are handled).
+2. The family's HTTP client is swapped for an `httpx2.MockTransport` that
+   returns a dummy body generated from the tool's output schema.
+3. Each tool is called through an in-memory FastMCP client, so input
+   validation, request building, response parsing, output-schema validation,
+   and the formatting middleware all run for real.
+4. A second pass verifies each tool is discoverable through `search_tools`.
+
+Run it (from a checkout with cached specs):
+
+```bash
+EQUINIX_MCP_CACHE_DIR=$PWD/.cache python scripts/vet_specs.py --report vet-report.md
+# or a subset:
+python scripts/vet_specs.py --families metal,fabric
+```
+
+## Findings (2026-08-05, 33 families, 690 tools)
+
+689/690 tools pass. The sweep surfaced three recurring spec authoring bugs,
+now repaired generically in `SpecManager._sanitize_schema_quirks` (no
+per-family overlays were needed):
+
+| Defect | Affected specs | Fix |
+|---|---|---|
+| `type: file` (Swagger 2.0 syntax in specs declaring openapi 3.0) | billingv1, reports | rewritten to `type: string, format: binary` |
+| ECMAScript regex named groups `(?<name>...)` in `pattern` | access | rewritten to Python-style `(?P<name>...)` (lookbehinds untouched) |
+| Boolean draft-4 `exclusiveMaximum`/`exclusiveMinimum` | attachments | dropped, keeping the inclusive bound — converting to the numeric 2020-12 form is rejected by the OpenAPI 3.0 document parser (dialect catch-22) |
+
+Provider construction is also resilient now: a family whose spec fails to
+parse is skipped and recorded in `EquinixMCPServer.failed_providers` instead
+of aborting startup.
+
+## Known issues
+
+- `metal_updateBgpSession`: the upstream spec declares the PUT request body
+  as a bare `type: boolean`. FastMCP's request builder does not serialize
+  primitive (non-object) JSON bodies and fails with
+  `Unexpected type for 'content', <class 'bool'>`. Not fixable with an
+  overlay without changing the wire format; candidate for an upstream
+  FastMCP issue.
+- Exact-tool-name search misses (6 tools, e.g. `metal_createDevice`,
+  `smartview_getAlerts`): these are precisely the largest-schema tools. The
+  BM25 index includes all parameter descriptions, so doc-length
+  normalization outranks them for short queries that also match many small
+  tools. Searching the bare operation name (`createDevice`) ranks them #1.
+  An upstream tuning question for FastMCP's search transform, not a spec
+  defect.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "exrex>=0.11.0",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",

--- a/scripts/vet_specs.py
+++ b/scripts/vet_specs.py
@@ -1,0 +1,340 @@
+"""Vet every generated API tool through the MCP harness.
+
+For each tool generated from the configured OpenAPI specs:
+1. Generate sample arguments from the tool's input schema.
+2. Point the family's HTTP client at a MockTransport that returns a dummy
+   response generated from the tool's output schema.
+3. Call the tool through an in-memory MCP client and record the outcome.
+4. Separately, verify each tool is discoverable through search_tools.
+
+No generic package exists for this, so the schema sampler below covers the
+JSON Schema constructs the Equinix specs actually use ($ref/$defs, allOf,
+oneOf/anyOf, enums, formats, type unions).
+
+Usage:  python scripts/vet_specs.py [--families a,b,c] [--report vet-report.md]
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import exrex  # noqa: E402
+import httpx2  # noqa: E402
+from fastmcp import Client  # noqa: E402
+
+from equinix_docs_mcp_server.main import (  # noqa: E402
+    DOCS_TOOL_NAMES,
+    EquinixMCPServer,
+)
+
+MAX_DEPTH = 8
+
+SAMPLE_FORMATS = {
+    "date": "2026-01-01",
+    "date-time": "2026-01-01T00:00:00Z",
+    "uuid": "00000000-0000-4000-8000-000000000000",
+    "email": "user@example.com",
+    "uri": "https://example.com/x",
+    "url": "https://example.com/x",
+    "hostname": "example.com",
+    "ipv4": "192.0.2.1",
+    "ipv6": "2001:db8::1",
+}
+
+
+def resolve_ref(ref: str, root: dict):
+    if not ref.startswith("#/"):
+        return None
+    node = root
+    for part in ref[2:].split("/"):
+        part = part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def merge_all_of(schema: dict, root: dict, depth: int = 0) -> dict:
+    """Flatten a schema's allOf chain (recursively) into one object schema.
+
+    Keeps the outer schema's own properties/required/type and merges every
+    branch, resolving $refs and nested allOfs along the way.
+    """
+    merged = {
+        "properties": dict(schema.get("properties", {})),
+        "required": list(schema.get("required", [])),
+    }
+    if "type" in schema:
+        merged["type"] = schema["type"]
+
+    if depth > MAX_DEPTH:
+        return merged
+
+    for sub in schema.get("allOf", []):
+        if isinstance(sub, dict) and "$ref" in sub:
+            sub = resolve_ref(sub["$ref"], root) or {}
+        if not isinstance(sub, dict):
+            continue
+        sub_merged = merge_all_of(sub, root, depth + 1)
+        merged["properties"].update(sub_merged["properties"])
+        merged["required"].extend(sub_merged["required"])
+        if "type" in sub_merged and "type" not in merged:
+            merged["type"] = sub_merged["type"]
+    return merged
+
+
+def sample_from_schema(schema, root=None, depth=0):
+    """Produce a value satisfying (a pragmatic subset of) a JSON Schema."""
+    if not isinstance(schema, dict):
+        return None
+    if depth > MAX_DEPTH:
+        # Depth cap: return the cheapest value of roughly the right shape
+        # instead of None, which fails non-nullable schemas.
+        stype = schema.get("type")
+        if stype == "array" or "items" in schema:
+            return []
+        if stype in (None, "object") or "properties" in schema:
+            return {}
+        return sample_from_schema({**schema, "properties": {}}, root, 0)
+    root = root if root is not None else schema
+
+    if "$ref" in schema:
+        target = resolve_ref(schema["$ref"], root)
+        if target is None:
+            raise ValueError(f"unresolvable $ref {schema['$ref']}")
+        return sample_from_schema(target, root, depth + 1)
+
+    if "const" in schema:
+        return schema["const"]
+    if "enum" in schema and schema["enum"]:
+        return schema["enum"][0]
+    if "default" in schema and schema["default"] is not None:
+        return schema["default"]
+
+    if "allOf" in schema:
+        merged = merge_all_of(schema, root)
+        if not merged.get("properties") and merged.get("type") not in (None, "object"):
+            return sample_from_schema(
+                {k: v for k, v in merged.items() if k != "allOf"}, root, depth + 1
+            )
+        return sample_from_schema({"type": "object", **merged}, root, depth + 1)
+
+    for key in ("oneOf", "anyOf"):
+        if key in schema and schema[key]:
+            return sample_from_schema(schema[key][0], root, depth + 1)
+
+    stype = schema.get("type")
+    if isinstance(stype, list):
+        non_null = [t for t in stype if t != "null"]
+        stype = non_null[0] if non_null else "null"
+    if stype is None:
+        if "properties" in schema:
+            stype = "object"
+        elif "items" in schema:
+            stype = "array"
+        else:
+            return "sample"
+
+    if stype == "null":
+        return None
+    if stype == "boolean":
+        return True
+    if stype == "integer":
+        return max(schema.get("minimum", 1), 1)
+    if stype == "number":
+        return float(schema.get("minimum", 1))
+    if stype == "string":
+        if schema.get("format") in SAMPLE_FORMATS:
+            return SAMPLE_FORMATS[schema["format"]]
+        if "pattern" in schema:
+            try:
+                return exrex.getone(schema["pattern"])
+            except Exception:
+                pass
+        value = "sample"
+        min_len = schema.get("minLength", 0)
+        if min_len > len(value):
+            value = value.ljust(min_len, "x")
+        max_len = schema.get("maxLength")
+        if max_len is not None and len(value) > max_len:
+            value = value[:max_len] or "s"[:max_len]
+        return value
+    if stype == "array":
+        min_items = schema.get("minItems", 0)
+        count = max(min_items, 1)
+        item = sample_from_schema(schema.get("items", {}), root, depth + 1)
+        return [item] * count
+    if stype == "object":
+        result = {}
+        props = schema.get("properties", {})
+        required = schema.get("required", [])
+        keys = required if required else list(props)[:2]
+        for key in keys:
+            if key in props:
+                result[key] = sample_from_schema(props[key], root, depth + 1)
+            else:
+                result[key] = "sample"
+        return result
+    return "sample"
+
+
+class VettingServer(EquinixMCPServer):
+    """EquinixMCPServer with all API traffic answered by a mock transport."""
+
+    def __init__(self, *args, **kwargs):
+        self.holder = {"body": None}
+        super().__init__(*args, **kwargs)
+
+    def _build_api_client(self, api_config):
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(200, json=self.holder["body"], request=request)
+
+        client = httpx2.AsyncClient(
+            base_url="https://api.equinix.com",
+            transport=httpx2.MockTransport(handler),
+        )
+        self._api_clients.append(client)
+        return client
+
+
+def categorize(error_text: str) -> str:
+    lowered = error_text.lower()
+    if "unresolvable $ref" in lowered:
+        return "unresolvable-ref-in-schema"
+    if "output" in lowered and ("valid" in lowered or "schema" in lowered):
+        return "output-validation"
+    if "input" in lowered and "valid" in lowered:
+        return "input-validation"
+    if "required" in lowered:
+        return "missing-required"
+    if "path" in lowered and "param" in lowered:
+        return "path-parameter"
+    return "other"
+
+
+async def vet(families_filter=None, report_path="vet-report.md"):
+    logging.disable(logging.ERROR)
+
+    server = VettingServer(tool_catalog="full")
+    await server.initialize()
+
+    families = sorted(name for name, api in server.config.apis.items() if api.enabled)
+    if families_filter:
+        families = [f for f in families if f in families_filter]
+    prefixes = tuple(f"{f}_" for f in families)
+
+    ok = Counter()
+    failures = defaultdict(list)  # family -> [(tool, category, message)]
+    for family, error in getattr(server, "failed_providers", {}).items():
+        if not families_filter or family in families_filter:
+            failures[family].append(("<provider>", "provider-build", error[:300]))
+
+    async with Client(server.mcp) as client:
+        tools = [
+            t
+            for t in await client.list_tools()
+            if t.name.startswith(prefixes) and t.name not in DOCS_TOOL_NAMES
+        ]
+        print(f"vetting {len(tools)} tools across {len(families)} families")
+
+        for i, tool in enumerate(tools):
+            family = tool.name.split("_", 1)[0]
+            try:
+                input_schema = tool.input_schema or {}
+                args = sample_from_schema(input_schema) or {}
+                if not isinstance(args, dict):
+                    args = {}
+
+                output_schema = tool.output_schema
+                if output_schema:
+                    body_schema = output_schema
+                    if output_schema.get("x-fastmcp-wrap-result"):
+                        body_schema = output_schema.get("properties", {}).get(
+                            "result", {}
+                        )
+                        body_schema = {
+                            **body_schema,
+                            "$defs": output_schema.get("$defs", {}),
+                        }
+                    server.holder["body"] = sample_from_schema(body_schema)
+                else:
+                    server.holder["body"] = {}
+
+                result = await client.call_tool(tool.name, args)
+                if result.is_error:
+                    text = result.content[0].text if result.content else "unknown"
+                    failures[family].append((tool.name, categorize(text), text[:300]))
+                else:
+                    ok[family] += 1
+            except Exception as e:
+                failures[family].append((tool.name, categorize(str(e)), str(e)[:300]))
+
+            if (i + 1) % 250 == 0:
+                print(f"  {i + 1}/{len(tools)} vetted")
+
+    # Search discoverability pass
+    search_server = VettingServer(tool_catalog="search")
+    await search_server.initialize()
+    not_searchable = []
+    async with Client(search_server.mcp) as client:
+        for tool in tools:
+            r = await client.call_tool("search_tools", {"query": tool.name})
+            names = {t["name"] for t in json.loads(r.content[0].text)}
+            if tool.name not in names:
+                not_searchable.append(tool.name)
+
+    # Report
+    lines = ["# Spec vetting report", ""]
+    total_fail = sum(len(v) for v in failures.values())
+    lines.append(
+        f"{sum(ok.values())} tools OK, {total_fail} failures, "
+        f"{len(not_searchable)} not discoverable by exact-name search."
+    )
+    lines.append("")
+    lines.append("| family | ok | failed |")
+    lines.append("|---|---|---|")
+    for family in families:
+        lines.append(f"| {family} | {ok[family]} | {len(failures[family])} |")
+    lines.append("")
+
+    category_counts = Counter(cat for fails in failures.values() for _, cat, _ in fails)
+    if category_counts:
+        lines.append("## Failure categories")
+        for cat, count in category_counts.most_common():
+            lines.append(f"- {cat}: {count}")
+        lines.append("")
+        lines.append("## Failures by family")
+        for family in families:
+            if not failures[family]:
+                continue
+            lines.append(f"### {family}")
+            for name, cat, msg in failures[family][:20]:
+                lines.append(f"- `{name}` [{cat}]: {msg}")
+            if len(failures[family]) > 20:
+                lines.append(f"- ... and {len(failures[family]) - 20} more")
+            lines.append("")
+
+    if not_searchable:
+        lines.append("## Not discoverable via search_tools (exact name query)")
+        for name in not_searchable[:50]:
+            lines.append(f"- `{name}`")
+        lines.append("")
+
+    Path(report_path).write_text("\n".join(lines), encoding="utf-8")
+    print(f"report written to {report_path}")
+    print(lines[2])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--families", help="comma-separated family filter")
+    parser.add_argument("--report", default="vet-report.md")
+    args = parser.parse_args()
+    families = set(args.families.split(",")) if args.families else None
+    asyncio.run(vet(families, args.report))

--- a/src/equinix_docs_mcp_server/data/config/apis.yaml
+++ b/src/equinix_docs_mcp_server/data/config/apis.yaml
@@ -174,6 +174,168 @@ apis:
       - url: "https://docs.equinix.com/api-catalog/workvisitsv2/openapi.yaml"
         overlay: "overlays/workvisitsv2.yaml"
 
+  accesstoken:
+    auth_type: "client_credentials"
+    service_name: "accesstoken"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/accesstokenv1/openapi.yaml"
+
+  access:
+    auth_type: "client_credentials"
+    service_name: "access"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/accessv1/openapi.yaml"
+
+  assets:
+    auth_type: "client_credentials"
+    service_name: "assets"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/assetsv1/openapi.yaml"
+
+  attachments:
+    auth_type: "client_credentials"
+    service_name: "attachments"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/attachmentsv1/openapi.yaml"
+
+  bas:
+    auth_type: "client_credentials"
+    service_name: "bas"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/basv2/openapi.yaml"
+
+  billingv1:
+    auth_type: "client_credentials"
+    service_name: "billingv1"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/billingv1/openapi.yaml"
+
+  crossconnects:
+    auth_type: "client_credentials"
+    service_name: "crossconnects"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/crossconnectsv2/openapi.yaml"
+
+  diloa:
+    auth_type: "client_credentials"
+    service_name: "diloa"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/diloav1/openapi.yaml"
+
+  getprojects:
+    auth_type: "client_credentials"
+    service_name: "getprojects"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/getprojectsv2/openapi.yaml"
+
+  internetaccess:
+    auth_type: "client_credentials"
+    service_name: "internetaccess"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/internetaccessv1/openapi.yaml"
+
+  internetaccessv2:
+    auth_type: "client_credentials"
+    service_name: "internetaccessv2"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/internetaccessv2/openapi.yaml"
+
+  lookup:
+    auth_type: "client_credentials"
+    service_name: "lookup"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/lookupv2/openapi.yaml"
+
+  notifications:
+    auth_type: "client_credentials"
+    service_name: "notifications"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/notificationsv1/openapi.yaml"
+
+  orderhistory:
+    auth_type: "client_credentials"
+    service_name: "orderhistory"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/orderhistoryv1/openapi.yaml"
+
+  orders:
+    auth_type: "client_credentials"
+    service_name: "orders"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/ordersv2/openapi.yaml"
+
+  quotes:
+    auth_type: "client_credentials"
+    service_name: "quotes"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/quotesv2/openapi.yaml"
+
+  reports:
+    auth_type: "client_credentials"
+    service_name: "reports"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/reportsv1/openapi.yaml"
+
+  securecabinet:
+    auth_type: "client_credentials"
+    service_name: "securecabinet"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/securecabinetv1/openapi.yaml"
+
+  shipments:
+    auth_type: "client_credentials"
+    service_name: "shipments"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/shipmentsv1/openapi.yaml"
+
+  shipmentsv2:
+    auth_type: "client_credentials"
+    service_name: "shipmentsv2"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/shipmentsv2/openapi.yaml"
+
+  smarthands:
+    auth_type: "client_credentials"
+    service_name: "smarthands"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/smarthandsv1/openapi.yaml"
+
+  sts:
+    auth_type: "client_credentials"
+    service_name: "sts"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/stsv1/openapi.yaml"
+
+  supportplans:
+    auth_type: "client_credentials"
+    service_name: "supportplans"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/supportplansv2/openapi.yaml"
+
+  support:
+    auth_type: "client_credentials"
+    service_name: "support"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/supportv2/openapi.yaml"
+
+  tickets:
+    auth_type: "client_credentials"
+    service_name: "tickets"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/ticketsv2/openapi.yaml"
+
+  troubleticket:
+    auth_type: "client_credentials"
+    service_name: "troubleticket"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/troubleticketv1/openapi.yaml"
+
+  unifiednotification:
+    auth_type: "client_credentials"
+    service_name: "unifiednotification"
+    specs:
+      - url: "https://docs.equinix.com/api-catalog/unifiednotificationv2/openapi.yaml"
+
 # Authentication configuration
 auth:
   # Client Credentials flow for most APIs

--- a/src/equinix_docs_mcp_server/main.py
+++ b/src/equinix_docs_mcp_server/main.py
@@ -195,8 +195,13 @@ class EquinixMCPServer:
         self._apply_catalog_transform()
 
     def _register_api_providers(self) -> None:
-        """Register one OpenAPI provider per enabled API family."""
+        """Register one OpenAPI provider per enabled API family.
+
+        A family whose spec fails to parse is skipped (and recorded in
+        ``failed_providers``) rather than aborting server startup.
+        """
         assert self.mcp is not None
+        self.failed_providers: dict[str, str] = {}
 
         for api_name, api_config in self.config.apis.items():
             if not api_config.enabled:
@@ -205,13 +210,19 @@ class EquinixMCPServer:
             spec = self.spec_manager.get_provider_spec(api_name)
             if not spec:
                 logger.warning(f"No cached spec for API '{api_name}'; skipping")
+                self.failed_providers[api_name] = "no cached spec"
                 continue
 
-            provider = OpenAPIProvider(
-                openapi_spec=spec,
-                client=self._build_api_client(api_config),
-                tags={"equinix", api_name},
-            )
+            try:
+                provider = OpenAPIProvider(
+                    openapi_spec=spec,
+                    client=self._build_api_client(api_config),
+                    tags={"equinix", api_name},
+                )
+            except Exception as e:
+                logger.error(f"Failed to build provider for '{api_name}': {e}")
+                self.failed_providers[api_name] = str(e)
+                continue
             # The namespace yields spec-conformant tool names like
             # "metal_findPlans" and guarantees per-server uniqueness across
             # API families.

--- a/src/equinix_docs_mcp_server/spec_manager.py
+++ b/src/equinix_docs_mcp_server/spec_manager.py
@@ -138,6 +138,10 @@ class SpecManager:
         except Exception as e:
             logger.debug(f"Could not apply autogen operationIds: {e}")
 
+        # Repair recurring authoring bugs that make otherwise-valid specs
+        # unparseable (found across the api-catalog by scripts/vet_specs.py).
+        self._sanitize_schema_quirks(merged_spec)
+
         # Ensure configured security scheme exists BEFORE normalization,
         # so operations can reference the right scheme.
         merged_spec.setdefault("components", {})
@@ -527,6 +531,45 @@ class SpecManager:
 
                 op["operationId"] = candidate
                 existing.add(candidate)
+
+    # ECMAScript named group syntax "(?<name>" that Python's regex validator
+    # rejects; must not touch lookbehinds "(?<=" / "(?<!".
+    _JS_NAMED_GROUP = re.compile(r"\(\?<(?![=!])")
+
+    def _sanitize_schema_quirks(self, node: Any) -> None:
+        """Fix common spec authoring bugs in place.
+
+        Found across the api-catalog by scripts/vet_specs.py:
+        - `type: file` is Swagger 2.0 syntax; several catalog specs declare
+          openapi 3.0 but still use it (billingv1, reports). OpenAPI 3
+          expresses binary payloads as string/binary.
+        - `pattern` regexes with ECMAScript named groups `(?<name>...)`
+          (access): JSON Schema validators built on Python's re require
+          `(?P<name>...)`.
+        - Boolean `exclusiveMaximum`/`exclusiveMinimum` (attachments) are
+          JSON Schema draft-4 syntax; tool schemas are validated as 2020-12
+          where they must be numeric. Converting to the numeric form would
+          break the OpenAPI 3.0 document parse (a catch-22 between the two
+          dialects), so drop the boolean and keep the inclusive bound.
+        """
+        if isinstance(node, dict):
+            if node.get("type") == "file":
+                node["type"] = "string"
+                node["format"] = "binary"
+
+            pattern = node.get("pattern")
+            if isinstance(pattern, str) and "(?<" in pattern:
+                node["pattern"] = self._JS_NAMED_GROUP.sub("(?P<", pattern)
+
+            for exclusive in ("exclusiveMaximum", "exclusiveMinimum"):
+                if isinstance(node.get(exclusive), bool):
+                    node.pop(exclusive)
+
+            for value in node.values():
+                self._sanitize_schema_quirks(value)
+        elif isinstance(node, list):
+            for item in node:
+                self._sanitize_schema_quirks(item)
 
     def get_provider_spec(self, api_name: str) -> Optional[Dict[str, Any]]:
         """Load one API family's spec, ready for provider registration.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
 """Test fixtures and configuration."""
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 
 import pytest
+
+# Test this checkout's sources: an editable install in a shared venv points
+# at whichever worktree ran `pip install -e .`, so prepend the local src.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_catalog_discovery.py
+++ b/tests/test_catalog_discovery.py
@@ -6,7 +6,23 @@ from equinix_docs_mcp_server.catalog_discovery import (
     extract_slugs,
     propose_config_entries,
 )
-from equinix_docs_mcp_server.config import Config
+from equinix_docs_mcp_server.config import APIConfig, Config, SpecSource
+
+
+def make_config() -> Config:
+    """A minimal config with one family, independent of the packaged file."""
+    return Config(
+        apis={
+            "fabric": APIConfig(
+                name="fabric",
+                specs=[
+                    SpecSource(
+                        url="https://docs.equinix.com/api-catalog/fabricv4/openapi.yaml"
+                    )
+                ],
+            )
+        }
+    )
 
 
 def test_extract_slugs_dedupes_and_sorts():
@@ -27,7 +43,7 @@ def test_configured_slugs_maps_to_families():
 
 
 def test_propose_config_entries():
-    config = Config.load()
+    config = make_config()
     entries = [
         CatalogEntry(
             slug="fabricv4",

--- a/tests/test_spec_manager.py
+++ b/tests/test_spec_manager.py
@@ -121,3 +121,54 @@ def test_apply_autogen_operation_ids_uniqueness(spec_manager):
     spec_manager._apply_autogen_operation_ids(spec)
 
     assert spec["paths"]["/other/things"]["get"]["operationId"] == "listThings2"
+
+
+def test_sanitize_schema_quirks(spec_manager):
+    """Recurring authoring bugs found by scripts/vet_specs.py are repaired."""
+    spec = {
+        "paths": {
+            "/download": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/octet-stream": {"schema": {"type": "file"}}
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Ern": {
+                    "type": "string",
+                    "pattern": "^ern:(?<cloud>[^:]+):(?<lookbehind>x)$",
+                },
+                "Lookbehind": {"type": "string", "pattern": "(?<=a)b(?<!c)"},
+                "Bounded": {
+                    "type": "integer",
+                    "maximum": 10,
+                    "exclusiveMaximum": True,
+                },
+                "BoundedFalse": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "exclusiveMinimum": False,
+                },
+            }
+        },
+    }
+
+    spec_manager._sanitize_schema_quirks(spec)
+
+    schemas = spec["components"]["schemas"]
+    file_schema = spec["paths"]["/download"]["get"]["responses"]["200"]["content"][
+        "application/octet-stream"
+    ]["schema"]
+    assert file_schema == {"type": "string", "format": "binary"}
+    assert schemas["Ern"]["pattern"] == "^ern:(?P<cloud>[^:]+):(?P<lookbehind>x)$"
+    # Lookbehind/lookahead syntax is untouched
+    assert schemas["Lookbehind"]["pattern"] == "(?<=a)b(?<!c)"
+    assert schemas["Bounded"] == {"type": "integer", "maximum": 10}
+    assert schemas["BoundedFalse"] == {"type": "integer", "minimum": 1}

--- a/vet-report.md
+++ b/vet-report.md
@@ -1,0 +1,54 @@
+# Spec vetting report
+
+689 tools OK, 1 failures, 6 not discoverable by exact-name search.
+
+| family | ok | failed |
+|---|---|---|
+| access | 39 | 0 |
+| accesstoken | 2 | 0 |
+| assets | 2 | 0 |
+| attachments | 5 | 0 |
+| bas | 3 | 0 |
+| billing | 2 | 0 |
+| billingv1 | 3 | 0 |
+| crossconnects | 3 | 0 |
+| diloa | 14 | 0 |
+| fabric | 194 | 0 |
+| getprojects | 1 | 0 |
+| internetaccess | 27 | 0 |
+| internetaccessv2 | 6 | 0 |
+| lookup | 5 | 0 |
+| metal | 218 | 1 |
+| network-edge | 54 | 0 |
+| notifications | 4 | 0 |
+| orderhistory | 2 | 0 |
+| orders | 5 | 0 |
+| quotes | 1 | 0 |
+| reports | 13 | 0 |
+| securecabinet | 2 | 0 |
+| shipments | 4 | 0 |
+| shipmentsv2 | 2 | 0 |
+| smarthands | 14 | 0 |
+| smartview | 33 | 0 |
+| sts | 10 | 0 |
+| support | 7 | 0 |
+| supportplans | 1 | 0 |
+| tickets | 5 | 0 |
+| troubleticket | 3 | 0 |
+| unifiednotification | 1 | 0 |
+| workvisit | 4 | 0 |
+
+## Failure categories
+- other: 1
+
+## Failures by family
+### metal
+- `metal_updateBgpSession` [other]: Error calling tool 'metal_updateBgpSession': Error building request for PUT /metal/v1/bgp/sessions/{id}: TypeError: Unexpected type for 'content', <class 'bool'>
+
+## Not discoverable via search_tools (exact name query)
+- `metal_createDevice`
+- `network-edge_createVirtualDevice`
+- `network-edge_createVirtualDeviceByUuid`
+- `network-edge_updateVirtualDeviceByUuid`
+- `network-edge_createDeviceRMAByUuid`
+- `smartview_getAlerts`


### PR DESCRIPTION
## Summary

Follow-up to the FastMCP 4 rebuild (merged upstream and synced here): vets the API catalog discovered from the Equinix docs portal and folds the results into the shipped configuration.

- **feat(config):** add the 27 API families discovered in the catalog to the bundled `apis.yaml`
- **fix(specs):** repair recurring spec authoring bugs (via overlays in `spec_manager.py`) and let the server survive individual provider failures instead of dying at startup
- **feat(vetting):** add `scripts/vet_specs.py`, which exercises every generated tool against schema-derived dummy responses, plus `docs/SPEC_VETTING.md` and the generated `vet-report.md`

## Test plan

- `pytest` — includes new `tests/test_spec_manager.py` overlay coverage and updated catalog-discovery tests
- `python scripts/vet_specs.py` regenerates `vet-report.md`; every tool in the catalog is invoked against dummy responses derived from its response schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)