### PR TITLE
feat(search): Surface family-level metadata to the catalog search transforms

### DIFF
--- a/src/equinix_docs_mcp_server/config.py
+++ b/src/equinix_docs_mcp_server/config.py
@@ -62,6 +62,17 @@ class APIConfig(BaseModel):
         default=None, description="Service name (used for path normalization)"
     )
     enabled: bool = Field(default=True, description="Enable/disable this API")
+    description: Optional[str] = Field(
+        default=None,
+        description="Human-readable summary of this API family; appended to "
+        "every generated tool description so catalog search can match tools "
+        "by product name. Overrides the spec's info title/description.",
+    )
+    tags: List[str] = Field(
+        default_factory=list,
+        description="Extra tags applied to this family's tools (in addition "
+        "to 'equinix' and the family name); aids code-mode tag browsing",
+    )
     include: List[str] = Field(
         default_factory=list,
         description="Regex patterns of operationIds to include (after prefix)",
@@ -189,6 +200,8 @@ class Config(BaseModel):
                     "auth_type": api_data.get("auth_type"),
                     "service_name": api_data.get("service_name"),
                     "enabled": api_data.get("enabled", True),
+                    "description": api_data.get("description"),
+                    "tags": api_data.get("tags", []) or [],
                     "include": api_data.get("include", []) or [],
                     "exclude": api_data.get("exclude", []) or [],
                     "format": api_data.get("format", {}) or {},

--- a/src/equinix_docs_mcp_server/data/config/apis.yaml
+++ b/src/equinix_docs_mcp_server/data/config/apis.yaml
@@ -2,6 +2,8 @@
 apis:
   # Metal API - uses different auth (X-Auth-Token) and base path
   metal:
+    description: "Equinix Metal bare metal servers: provision and manage on-demand dedicated servers, IPs, and VLANs."
+    tags: [compute, bare-metal]
     auth_type: "metal_token"
     service_name: "metal"
     format:
@@ -41,6 +43,7 @@ apis:
 
   # Network Edge API
   network-edge:
+    tags: [network, virtual-devices]
     auth_type: "client_credentials"
     service_name: "network-edge"
     enabled: true
@@ -72,6 +75,7 @@ apis:
 
   # Fabric API
   fabric:
+    tags: [network, interconnection]
     auth_type: "client_credentials"
     service_name: "fabric"
     format:
@@ -150,6 +154,7 @@ apis:
 
   # Billing API
   billing:
+    tags: [billing]
     auth_type: "client_credentials"
     service_name: "billing"
     specs:
@@ -157,6 +162,7 @@ apis:
         overlay: "overlays/billing.yaml"
   # SmartView APIs
   smartview:
+    tags: [colocation, monitoring, power]
     service_name: "smartview"
     specs:
       # The former per-domain Smart View specs (environmentalv1/v2,
@@ -166,6 +172,8 @@ apis:
 
   # Work Visit APIs
   workvisit:
+    description: "Schedule and manage work visits (on-site access to Equinix IBX data centers)."
+    tags: [colocation, site-access]
     auth_type: "client_credentials"
     service_name: "workvisit"
     specs:
@@ -175,162 +183,201 @@ apis:
         overlay: "overlays/workvisitsv2.yaml"
 
   accesstoken:
+    description: "Obtain OAuth2 API access tokens (legacy Equinix API authentication)."
+    tags: [auth, identity]
     auth_type: "client_credentials"
     service_name: "accesstoken"
     specs:
       - url: "https://docs.equinix.com/api-catalog/accesstokenv1/openapi.yaml"
 
   access:
+    tags: [identity, permissions]
     auth_type: "client_credentials"
     service_name: "access"
     specs:
       - url: "https://docs.equinix.com/api-catalog/accessv1/openapi.yaml"
 
   assets:
+    tags: [colocation, assets]
     auth_type: "client_credentials"
     service_name: "assets"
     specs:
       - url: "https://docs.equinix.com/api-catalog/assetsv1/openapi.yaml"
 
   attachments:
+    tags: [portal, files]
     auth_type: "client_credentials"
     service_name: "attachments"
     specs:
       - url: "https://docs.equinix.com/api-catalog/attachmentsv1/openapi.yaml"
 
   bas:
+    description: "Billing Account Service (BAS): search and retrieve customer billing accounts."
+    tags: [billing]
     auth_type: "client_credentials"
     service_name: "bas"
     specs:
       - url: "https://docs.equinix.com/api-catalog/basv2/openapi.yaml"
 
   billingv1:
+    tags: [billing]
     auth_type: "client_credentials"
     service_name: "billingv1"
     specs:
       - url: "https://docs.equinix.com/api-catalog/billingv1/openapi.yaml"
 
   crossconnects:
+    description: "Order and manage physical cross connects between colocation deployments."
+    tags: [interconnection, colocation]
     auth_type: "client_credentials"
     service_name: "crossconnects"
     specs:
       - url: "https://docs.equinix.com/api-catalog/crossconnectsv2/openapi.yaml"
 
   diloa:
+    description: "Digital Letter of Authorization (LOA): authorize cross connect and interconnection provisioning."
+    tags: [interconnection, colocation]
     auth_type: "client_credentials"
     service_name: "diloa"
     specs:
       - url: "https://docs.equinix.com/api-catalog/diloav1/openapi.yaml"
 
   getprojects:
+    description: "Retrieve Equinix projects."
+    tags: [projects]
     auth_type: "client_credentials"
     service_name: "getprojects"
     specs:
       - url: "https://docs.equinix.com/api-catalog/getprojectsv2/openapi.yaml"
 
   internetaccess:
+    description: "Equinix Internet Access (EIA): order and manage dedicated internet service."
+    tags: [network, internet]
     auth_type: "client_credentials"
     service_name: "internetaccess"
     specs:
       - url: "https://docs.equinix.com/api-catalog/internetaccessv1/openapi.yaml"
 
   internetaccessv2:
+    description: "Equinix Internet Access (EIA): order and manage dedicated internet service."
+    tags: [network, internet]
     auth_type: "client_credentials"
     service_name: "internetaccessv2"
     specs:
       - url: "https://docs.equinix.com/api-catalog/internetaccessv2/openapi.yaml"
 
   lookup:
+    tags: [colocation, lookup]
     auth_type: "client_credentials"
     service_name: "lookup"
     specs:
       - url: "https://docs.equinix.com/api-catalog/lookupv2/openapi.yaml"
 
   notifications:
+    tags: [notifications]
     auth_type: "client_credentials"
     service_name: "notifications"
     specs:
       - url: "https://docs.equinix.com/api-catalog/notificationsv1/openapi.yaml"
 
   orderhistory:
+    tags: [ordering]
     auth_type: "client_credentials"
     service_name: "orderhistory"
     specs:
       - url: "https://docs.equinix.com/api-catalog/orderhistoryv1/openapi.yaml"
 
   orders:
+    tags: [ordering]
     auth_type: "client_credentials"
     service_name: "orders"
     specs:
       - url: "https://docs.equinix.com/api-catalog/ordersv2/openapi.yaml"
 
   quotes:
+    tags: [ordering]
     auth_type: "client_credentials"
     service_name: "quotes"
     specs:
       - url: "https://docs.equinix.com/api-catalog/quotesv2/openapi.yaml"
 
   reports:
+    tags: [reports]
     auth_type: "client_credentials"
     service_name: "reports"
     specs:
       - url: "https://docs.equinix.com/api-catalog/reportsv1/openapi.yaml"
 
   securecabinet:
+    description: "Order and manage Equinix Secure Cabinet colocation products."
+    tags: [colocation, ordering]
     auth_type: "client_credentials"
     service_name: "securecabinet"
     specs:
       - url: "https://docs.equinix.com/api-catalog/securecabinetv1/openapi.yaml"
 
   shipments:
+    description: "Manage inbound and outbound equipment shipments to Equinix IBX data centers."
+    tags: [colocation, shipments]
     auth_type: "client_credentials"
     service_name: "shipments"
     specs:
       - url: "https://docs.equinix.com/api-catalog/shipmentsv1/openapi.yaml"
 
   shipmentsv2:
+    description: "Manage inbound and outbound equipment shipments to Equinix IBX data centers."
+    tags: [colocation, shipments]
     auth_type: "client_credentials"
     service_name: "shipmentsv2"
     specs:
       - url: "https://docs.equinix.com/api-catalog/shipmentsv2/openapi.yaml"
 
   smarthands:
+    description: "Order Equinix Smart Hands remote 'hands and eyes' support tasks performed by on-site technicians."
+    tags: [support, ordering]
     auth_type: "client_credentials"
     service_name: "smarthands"
     specs:
       - url: "https://docs.equinix.com/api-catalog/smarthandsv1/openapi.yaml"
 
   sts:
+    description: "Security Token Service (STS): exchange OIDC ID tokens for Equinix access tokens."
+    tags: [auth, identity]
     auth_type: "client_credentials"
     service_name: "sts"
     specs:
       - url: "https://docs.equinix.com/api-catalog/stsv1/openapi.yaml"
 
   supportplans:
+    tags: [support]
     auth_type: "client_credentials"
     service_name: "supportplans"
     specs:
       - url: "https://docs.equinix.com/api-catalog/supportplansv2/openapi.yaml"
 
   support:
+    tags: [support]
     auth_type: "client_credentials"
     service_name: "support"
     specs:
       - url: "https://docs.equinix.com/api-catalog/supportv2/openapi.yaml"
 
   tickets:
+    tags: [support]
     auth_type: "client_credentials"
     service_name: "tickets"
     specs:
       - url: "https://docs.equinix.com/api-catalog/ticketsv2/openapi.yaml"
 
   troubleticket:
+    tags: [support]
     auth_type: "client_credentials"
     service_name: "troubleticket"
     specs:
       - url: "https://docs.equinix.com/api-catalog/troubleticketv1/openapi.yaml"
 
   unifiednotification:
+    tags: [notifications]
     auth_type: "client_credentials"
     service_name: "unifiednotification"
     specs:

--- a/src/equinix_docs_mcp_server/main.py
+++ b/src/equinix_docs_mcp_server/main.py
@@ -217,7 +217,7 @@ class EquinixMCPServer:
                 provider = OpenAPIProvider(
                     openapi_spec=spec,
                     client=self._build_api_client(api_config),
-                    tags={"equinix", api_name},
+                    tags={"equinix", api_name, *api_config.tags},
                 )
             except Exception as e:
                 logger.error(f"Failed to build provider for '{api_name}': {e}")

--- a/src/equinix_docs_mcp_server/response_formatter.py
+++ b/src/equinix_docs_mcp_server/response_formatter.py
@@ -50,7 +50,7 @@ class ResponseFormatter:
 
         for i, jq_filter in enumerate(filters):
             try:
-                logger.debug(f"Applying JQ filter {i+1}/{len(filters)}: {jq_filter}")
+                logger.debug(f"Applying JQ filter {i + 1}/{len(filters)}: {jq_filter}")
                 program = self._get_jq_program(jq_filter)
                 if program is None:
                     logger.warning(f"JQ program is None for filter: {jq_filter}")
@@ -71,7 +71,7 @@ class ResponseFormatter:
                     logger.debug(f"Using raw result: {type(result)}")
 
                 logger.debug(
-                    f"After filter {i+1}, result type: {type(result)}, value: {repr(result)[:200] if result else 'None'}"
+                    f"After filter {i + 1}, result type: {type(result)}, value: {repr(result)[:200] if result else 'None'}"
                 )
 
             except Exception as e:

--- a/src/equinix_docs_mcp_server/spec_manager.py
+++ b/src/equinix_docs_mcp_server/spec_manager.py
@@ -198,7 +198,16 @@ class SpecManager:
 
         self.save_merged_spec(api_name, merged_spec)
 
-    _HTTP_METHODS = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+    _HTTP_METHODS = (
+        "get",
+        "put",
+        "post",
+        "delete",
+        "options",
+        "head",
+        "patch",
+        "trace",
+    )
 
     def _inject_family_context(
         self, spec: Dict[str, Any], api_name: str, api_config: APIConfig

--- a/src/equinix_docs_mcp_server/spec_manager.py
+++ b/src/equinix_docs_mcp_server/spec_manager.py
@@ -142,6 +142,11 @@ class SpecManager:
         # unparseable (found across the api-catalog by scripts/vet_specs.py).
         self._sanitize_schema_quirks(merged_spec)
 
+        # Catalog search transforms only index per-tool text (name,
+        # description, parameters), so family-level context from info.title
+        # would otherwise be invisible to search.
+        self._inject_family_context(merged_spec, api_name, api_config)
+
         # Ensure configured security scheme exists BEFORE normalization,
         # so operations can reference the right scheme.
         merged_spec.setdefault("components", {})
@@ -192,6 +197,59 @@ class SpecManager:
                 merged_spec["security"] = [{"MetalToken": []}]
 
         self.save_merged_spec(api_name, merged_spec)
+
+    _HTTP_METHODS = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+    def _inject_family_context(
+        self, spec: Dict[str, Any], api_name: str, api_config: APIConfig
+    ) -> None:
+        """Append family-level context to every operation description.
+
+        FastMCP derives each tool's description from the operation's
+        description (falling back to summary), and the catalog search
+        transforms index only that per-tool text. The spec's info block —
+        often the best statement of what the API family does (e.g. the
+        "diloa" family is titled "Digital LOA API") — never reaches the
+        index unless it is folded into each operation.
+        """
+        info = spec.get("info") or {}
+        title = str(info.get("title") or "").strip()
+        family_desc = (api_config.description or "").strip()
+        if not family_desc:
+            family_desc = self._summarize_info_description(
+                str(info.get("description") or "")
+            )
+
+        label = re.sub(r"\s+APIs?$", "", title) or api_name
+        parts = [f"Part of the Equinix {label} API family ({api_name})."]
+        if family_desc and family_desc.rstrip(".") != title.rstrip("."):
+            parts.append(family_desc.rstrip(".") + ".")
+        context = " ".join(parts)
+
+        for path_item in (spec.get("paths") or {}).values():
+            if not isinstance(path_item, dict):
+                continue
+            for method in self._HTTP_METHODS:
+                operation = path_item.get(method)
+                if not isinstance(operation, dict):
+                    continue
+                existing = str(
+                    operation.get("description") or operation.get("summary") or ""
+                ).strip()
+                if context in existing:
+                    continue
+                operation["description"] = (
+                    f"{existing}\n\n{context}" if existing else context
+                )
+
+    @staticmethod
+    def _summarize_info_description(text: str, max_len: int = 300) -> str:
+        """Collapse an info.description to a short single-line summary."""
+        collapsed = " ".join(text.split())
+        if len(collapsed) <= max_len:
+            return collapsed
+        cut = collapsed[:max_len].rsplit(" ", 1)[0]
+        return cut + "…"
 
     async def _fetch_and_cache_spec(
         self, spec_key: str, url: str

--- a/src/equinix_docs_mcp_server/swagger2openapi/converter.py
+++ b/src/equinix_docs_mcp_server/swagger2openapi/converter.py
@@ -70,11 +70,11 @@ class Swagger2OpenAPIConverter:
     def _rewrite_ref(self, ref):
         """Rewrites a Swagger $ref to an OpenAPI $ref."""
         if ref.startswith("#/definitions/"):
-            return f"#/components/schemas/{ref[len('#/definitions/'):]}"
+            return f"#/components/schemas/{ref[len('#/definitions/') :]}"
         if ref.startswith("#/parameters/"):
-            return f"#/components/parameters/{ref[len('#/parameters/'):]}"
+            return f"#/components/parameters/{ref[len('#/parameters/') :]}"
         if ref.startswith("#/responses/"):
-            return f"#/components/responses/{ref[len('#/responses/'):]}"
+            return f"#/components/responses/{ref[len('#/responses/') :]}"
         return ref
 
     def _fixup_refs(self, obj):

--- a/tests/test_spec_manager.py
+++ b/tests/test_spec_manager.py
@@ -75,9 +75,9 @@ def test_overlay_files_exist(config):
         for spec in api_config.specs:
             if spec.overlay:
                 overlay_path = config.resolve_path(spec.overlay)
-                assert overlay_path.exists(), (
-                    f"Overlay file missing for {api_name}: {overlay_path}"
-                )
+                assert (
+                    overlay_path.exists()
+                ), f"Overlay file missing for {api_name}: {overlay_path}"
 
 
 def test_apply_autogen_operation_ids(spec_manager):

--- a/tests/test_spec_manager.py
+++ b/tests/test_spec_manager.py
@@ -75,9 +75,9 @@ def test_overlay_files_exist(config):
         for spec in api_config.specs:
             if spec.overlay:
                 overlay_path = config.resolve_path(spec.overlay)
-                assert (
-                    overlay_path.exists()
-                ), f"Overlay file missing for {api_name}: {overlay_path}"
+                assert overlay_path.exists(), (
+                    f"Overlay file missing for {api_name}: {overlay_path}"
+                )
 
 
 def test_apply_autogen_operation_ids(spec_manager):

--- a/tests/test_spec_manager.py
+++ b/tests/test_spec_manager.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from equinix_docs_mcp_server.config import Config
+from equinix_docs_mcp_server.config import APIConfig, Config
 from equinix_docs_mcp_server.spec_manager import SpecManager
 
 
@@ -172,3 +172,78 @@ def test_sanitize_schema_quirks(spec_manager):
     assert schemas["Lookbehind"]["pattern"] == "(?<=a)b(?<!c)"
     assert schemas["Bounded"] == {"type": "integer", "maximum": 10}
     assert schemas["BoundedFalse"] == {"type": "integer", "minimum": 1}
+
+
+def test_inject_family_context(spec_manager):
+    """Family context from the info block reaches every operation description."""
+    spec = {
+        "info": {"title": "Digital LOA API", "description": "Digital LOA API"},
+        "paths": {
+            "/orgs": {
+                "get": {"summary": "Marketplace organizations selection"},
+                "post": {"description": "Create an organization."},
+            },
+            "/bare": {"get": {}},
+        },
+    }
+    api_config = APIConfig(name="diloa")
+
+    spec_manager._inject_family_context(spec, "diloa", api_config)
+
+    context = "Part of the Equinix Digital LOA API family (diloa)."
+    ops = spec["paths"]
+    # Summary-only operations get a description built from the summary
+    assert ops["/orgs"]["get"]["description"] == (
+        f"Marketplace organizations selection\n\n{context}"
+    )
+    assert ops["/orgs"]["post"]["description"] == (
+        f"Create an organization.\n\n{context}"
+    )
+    assert ops["/bare"]["get"]["description"] == context
+
+    # Idempotent: a second pass adds nothing
+    spec_manager._inject_family_context(spec, "diloa", api_config)
+    assert ops["/bare"]["get"]["description"] == context
+
+
+def test_inject_family_context_config_override(spec_manager):
+    """An apis.yaml family description overrides the spec's info.description."""
+    spec = {
+        "info": {"title": "Digital LOA API", "description": "Digital LOA API"},
+        "paths": {"/orgs": {"get": {"summary": "List organizations"}}},
+    }
+    api_config = APIConfig(
+        name="diloa",
+        description="Digital Letter of Authorization (LOA) for cross connects.",
+    )
+
+    spec_manager._inject_family_context(spec, "diloa", api_config)
+
+    desc = spec["paths"]["/orgs"]["get"]["description"]
+    assert "Digital Letter of Authorization (LOA) for cross connects." in desc
+    assert desc.startswith("List organizations")
+
+
+def test_summarize_info_description():
+    """Long multi-line info descriptions collapse to a bounded single line."""
+    text = "First line\nof a very long description. " * 30
+    summary = SpecManager._summarize_info_description(text)
+    assert "\n" not in summary
+    assert len(summary) <= 301
+    assert summary.endswith("…")
+    # Short descriptions pass through collapsed but untruncated
+    assert SpecManager._summarize_info_description("a  b\nc") == "a b c"
+
+
+def test_config_family_search_metadata(config):
+    """The bundled config carries description/tags for opaque family slugs."""
+    diloa = config.get_api_config("diloa")
+    assert "Letter of Authorization" in (diloa.description or "")
+    assert "interconnection" in diloa.tags
+
+    sts = config.get_api_config("sts")
+    assert "Security Token Service" in (sts.description or "")
+
+    # Every family carries at least one grouping tag
+    for api_name in config.get_api_names():
+        assert config.get_api_config(api_name).tags, f"{api_name} has no tags"


### PR DESCRIPTION
## Summary

The catalog search transforms (`BM25SearchTransform` / code-mode `Search`) index only per-tool text — name, description, and parameters — so the spec `info` block, which is often the only statement of what an API family does, never reached the search index. Code-mode's `GetTags` browsing likewise saw nothing but opaque family slugs (`diloa`, `bas`, `sts`…).

- **spec_manager:** during merge, append `Part of the Equinix <title> API family (<name>).` plus a short family summary to every operation description (built from the operation summary when no description exists — FastMCP falls back in that order). A search for "letter of authorization" now matches `diloa_*` tools.
- **config:** new optional per-family `description` and `tags` fields in `apis.yaml`. `description` overrides weak spec info blocks; `tags` are added to each family's `OpenAPIProvider(tags=...)` so code-mode tag browsing gets meaningful groupings.
- **apis.yaml:** authored descriptions for the 14 families whose spec text lacks the obvious search terms (diloa → "Digital Letter of Authorization (LOA)", bas → "Billing Account Service", sts, smarthands, …) and grouping tags (billing, support, interconnection, colocation, …) for all 33 families.

## Test plan

- `pytest` — 62 passed, including new coverage for the injection (summary fallback, idempotence, config override, truncation) and for the bundled config metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)